### PR TITLE
Test in more platforms

### DIFF
--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -165,6 +165,20 @@ jobs:
       - name: Conda List
         run: conda list --show-channel-urls
 
+      - name: Setup PowerShell
+        # for tests/shell, so only necessary for integration tests
+        if: matrix.test-type == 'integration'
+        run: |
+          Invoke-Expression "& { $(Invoke-RestMethod https://aka.ms/install-powershell.ps1) }"
+          "PWSHPATH=$env:LOCALAPPDATA\Microsoft\powershell" | Out-File -FilePath $env:GITHUB_ENV -Append
+
+      - name: PowerShell Info
+        # for tests/shell, so only necessary for integration tests
+        if: matrix.test-type == 'integration'
+        run: |
+          Get-Command -All powershell
+          Get-Command -All "$env:PWSHPATH\pwsh.exe"
+
       - name: Run Upstream Tests
         working-directory: conda  # CONDA-RATTLER-SOLVER CHANGE
         if: ${{ matrix.test-type != 'conda-rattler-solver' }}  # CONDA-RATTLER-SOLVER CHANGE
@@ -176,21 +190,17 @@ jobs:
           --reruns=${{ env.PYTEST_RERUN_FAILURES }}
           -m "${{ env.PYTEST_MARKER }}"
 
-      # CONDA-RATTLER-SOLVER CHANGE
+      # CONDA-LIBMAMBA-SOLVER CHANGE
       - name: Run conda-rattler-solver Tests
         working-directory: conda-rattler-solver
         if: ${{ matrix.test-type == 'conda-rattler-solver' }}
-        shell: cmd /C CALL {0}
+        shell: bash -el {0}
         run: |
-          CALL python -m pip install -e ../conda/ --no-deps
-          if errorlevel 1 exit 1
-          CALL python -m conda init --all
-          if errorlevel 1 exit 1
-          CALL %CONDA_PREFIX%\Scripts\activate.bat
-          if errorlevel 1 exit 1
-          python -m pytest -vv -m "not slow" --reruns=${{ env.PYTEST_RERUN_FAILURES }} --durations=16 || exit 1
-          exit 0
-      #/ CONDA-RATTLER-SOLVER CHANGE
+          python -m pip install -e ../conda/ --no-deps
+          python -m conda init --all
+          . $CONDA_PREFIX/etc/profile.d/conda.sh
+          python -m pytest -vv -m "not slow" --reruns=${{ env.PYTEST_RERUN_FAILURES }} --durations=16
+      #/ CONDA-LIBMAMBA-SOLVER CHANGE
 
       - name: Upload Coverage
         uses: codecov/codecov-action@v4

--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -71,16 +71,15 @@ jobs:
   windows:
     # only run test suite if there are code changes
     needs: changes
-    if: false
-    # if: needs.changes.outputs.code == 'true'
+    if: needs.changes.outputs.code == 'true'
 
     runs-on: windows-latest
     strategy:
       fail-fast: false
       matrix:
         # test lower version (w/ defaults) and upper version (w/ defaults and conda-forge)
-        python-version: ['3.8', '3.11', '3.12']  # CONDA-RATTLER-SOLVER CHANGE
-        default-channel: [defaults, conda-forge]
+        python-version: ['3.10']  # ['3.8', '3.11', '3.12']  # CONDA-RATTLER-SOLVER CHANGE
+        default-channel: [conda-forge]  # [defaults, conda-forge]
         test-type: [conda-rattler-solver, unit, integration]  # CONDA-RATTLER-SOLVER CHANGE
         test-group: [1, 2, 3]
         exclude:
@@ -508,8 +507,8 @@ jobs:
       matrix:
         # test lower version (w/ osx-64 & defaults & unit tests) and upper version (w/ osx-arm64 & conda-forge & integration tests)
         arch: [osx-64, osx-arm64]
-        python-version: ['3.8', '3.11']
-        default-channel: [defaults, conda-forge]
+        python-version: ['3.10']  # ['3.8', '3.11']
+        default-channel: [conda-forge]  #[defaults, conda-forge]
         test-type: [conda-rattler-solver, unit, integration]  # CONDA-RATTLER-SOLVER CHANGE
         test-group: [1, 2, 3]
         exclude:

--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -126,11 +126,11 @@ jobs:
         shell: bash  # use bash to run date command
         run: echo "HASH=${{ runner.os }}-${{ runner.arch }}-Py${{ matrix.python-version }}-${{ matrix.default-channel }}-${{ matrix.test-type }}-${{ matrix.test-group }}-$(date -u "+%Y%m")" >> $GITHUB_ENV
 
-      - name: Cache Conda
-        uses: actions/cache@v4
-        with:
-          path: ~/conda_pkgs_dir
-          key: cache-${{ env.HASH }}
+      # - name: Cache Conda
+      #   uses: actions/cache@v4
+      #   with:
+      #     path: ~/conda_pkgs_dir
+      #     key: cache-${{ env.HASH }}
 
       - name: Setup Miniconda
         uses: conda-incubator/setup-miniconda@v3
@@ -145,6 +145,7 @@ jobs:
         run: >
           conda install
           --yes
+          --quiet
           --file tests\requirements.txt
           --file tests\requirements-${{ runner.os }}.txt
           --file tests\requirements-ci.txt
@@ -156,7 +157,7 @@ jobs:
 
       # CONDA-RATTLER-SOLVER CHANGE
       - name: Install conda-rattler-solver
-        run: python -m pip install -e conda-rattler-solver/ -vv --no-deps
+        run: python -m pip install -e conda-rattler-solver/ --no-deps
       #/ CONDA-RATTLER-SOLVER CHANGE
 
       - name: Conda Info
@@ -304,6 +305,7 @@ jobs:
         working-directory: conda
         run: conda install
           --yes
+          --quiet
           --file tests/requirements.txt
           --file tests/requirements-${{ runner.os }}.txt
           --file tests/requirements-ci.txt
@@ -315,7 +317,7 @@ jobs:
 
       # CONDA-RATTLER-SOLVER CHANGE
       - name: Install conda-rattler-solver
-        run: python -m pip install -e conda-rattler-solver/ -vv --no-deps
+        run: python -m pip install -e conda-rattler-solver/ --no-deps
       #/ CONDA-RATTLER-SOLVER CHANGE
 
       - name: Conda Info
@@ -417,6 +419,7 @@ jobs:
       - name: Conda Install
         run: conda install
           --yes
+          --quiet
           --file tests/requirements.txt
           --file tests/requirements-${{ runner.os }}.txt
           --file tests/requirements-ci.txt
@@ -596,6 +599,7 @@ jobs:
         # CONDA-RATTLER-SOLVER CHANGE: add conda-rattler-solver requirements.txt
         run: conda install
           --yes
+          --quiet
           --file tests/requirements.txt
           --file tests/requirements-ci.txt
           --file tests/requirements-s3.txt
@@ -606,7 +610,7 @@ jobs:
 
       # CONDA-RATTLER-SOLVER CHANGE
       - name: Install conda-rattler-solver
-        run: python -m pip install -e conda-rattler-solver/ -vv --no-deps
+        run: python -m pip install -e conda-rattler-solver/ --no-deps
       #/ CONDA-RATTLER-SOLVER CHANGE
 
       - name: Setup Shells

--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -504,8 +504,7 @@ jobs:
   macos:
     # only run test suite if there are code changes
     needs: changes
-    if: false
-    # if: needs.changes.outputs.code == 'true'
+    if: needs.changes.outputs.code == 'true'
 
     runs-on: ${{ (matrix.arch == 'osx-64' && 'macos-13') || 'macos-14' }}
     defaults:

--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -189,7 +189,6 @@ jobs:
           --splits=${{ env.PYTEST_SPLITS }}
           --reruns=${{ env.PYTEST_RERUN_FAILURES }}
           -m "${{ env.PYTEST_MARKER }}"
-          --sw
 
       # CONDA-RATTLER-SOLVER CHANGE
       - name: Run conda-rattler-solver Tests
@@ -200,7 +199,7 @@ jobs:
           python -m pip install -e ../conda/ --no-deps
           python -m conda init --all
           . $CONDA_PREFIX/etc/profile.d/conda.sh
-          python -m pytest -vv -m "not slow" --reruns=${{ env.PYTEST_RERUN_FAILURES }} --durations=16 --sw
+          python -m pytest -vv -m "not slow" --reruns=${{ env.PYTEST_RERUN_FAILURES }} --durations=16
       #/ CONDA-RATTLER-SOLVER CHANGE
 
       - name: Upload Coverage

--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -73,9 +73,7 @@ jobs:
     # only run test suite if there are code changes
     needs: changes
     if: needs.changes.outputs.code == 'true'
-    env:
-      PYTEST_RERUN_FAILURES: 2
-      PYTEST_RERUN_FAILURES_DELAY: 5
+
     runs-on: windows-latest
     strategy:
       fail-fast: false
@@ -103,6 +101,8 @@ jobs:
       PYTEST_MARKER: ${{ matrix.test-type == 'unit' && 'not integration' || 'integration' }}
       PYTEST_SPLITS: ${{ matrix.test-type == 'unit' && '2' || '3' }}
       REQUIREMENTS_TRUSTSTORE: ${{ contains('3.10|3.11|3.12', matrix.python-version) && '--file tests\requirements-truststore.txt' || '' }}
+      PYTEST_RERUN_FAILURES: 2
+      PYTEST_RERUN_FAILURES_DELAY: 5
 
     steps:
       - name: Checkout conda/conda # CONDA-RATTLER-SOLVER CHANGE

--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -30,7 +30,8 @@ concurrency:
   cancel-in-progress: true
 
 env:
-  PYTEST_RERUN_FAILURES: 2
+  PYTEST_RERUN_FAILURES: 0
+  PYTEST_RERUN_FAILURES_DELAY: 0
   # See https://github.com/conda/conda/pull/13694
   # we can't break classic from here; no need to test it
   # those tests will still be available for local debugging if necessary
@@ -72,7 +73,9 @@ jobs:
     # only run test suite if there are code changes
     needs: changes
     if: needs.changes.outputs.code == 'true'
-
+    env:
+      PYTEST_RERUN_FAILURES: 2
+      PYTEST_RERUN_FAILURES_DELAY: 5
     runs-on: windows-latest
     strategy:
       fail-fast: false
@@ -188,6 +191,7 @@ jobs:
           --group=${{ matrix.test-group }}
           --splits=${{ env.PYTEST_SPLITS }}
           --reruns=${{ env.PYTEST_RERUN_FAILURES }}
+          --reruns-delay ${{ env.PYTEST_RERUN_FAILURES_DELAY }}
           -m "${{ env.PYTEST_MARKER }}"
 
       # CONDA-RATTLER-SOLVER CHANGE
@@ -199,7 +203,7 @@ jobs:
           python -m pip install -e ../conda/ --no-deps
           python -m conda init --all
           . $CONDA_PREFIX/etc/profile.d/conda.sh
-          python -m pytest -vv -m "not slow" --reruns=${{ env.PYTEST_RERUN_FAILURES }} --durations=16
+          python -m pytest -vv -m "not slow" --reruns=${{ env.PYTEST_RERUN_FAILURES }} --reruns-delay=${{ env.PYTEST_RERUN_FAILURES_DELAY }} --durations=16
       #/ CONDA-RATTLER-SOLVER CHANGE
 
       - name: Upload Coverage
@@ -337,6 +341,7 @@ jobs:
           --group=${{ matrix.test-group }}
           --splits=${{ env.PYTEST_SPLITS }}
           --reruns=${{ env.PYTEST_RERUN_FAILURES }}
+          --reruns-delay ${{ env.PYTEST_RERUN_FAILURES_DELAY }}
           -m "${{ env.PYTEST_MARKER }}"
 
       # CONDA-RATTLER-SOLVER CHANGE
@@ -347,7 +352,7 @@ jobs:
           python -m pip install -e ../conda/ --no-deps
           python -m conda init --all
           . $CONDA_PREFIX/etc/profile.d/conda.sh
-          python -m pytest -vv -m "not slow" --reruns=${{ env.PYTEST_RERUN_FAILURES }} --durations=16
+          python -m pytest -vv -m "not slow" --reruns=${{ env.PYTEST_RERUN_FAILURES }} --reruns-delay ${{ env.PYTEST_RERUN_FAILURES_DELAY }} --durations=16
       #/ CONDA-RATTLER-SOLVER CHANGE
 
       - name: Upload Coverage
@@ -627,6 +632,7 @@ jobs:
           --group=${{ matrix.test-group }}
           --splits=${{ env.PYTEST_SPLITS }}
           --reruns=${{ env.PYTEST_RERUN_FAILURES }}
+          --reruns-delay ${{ env.PYTEST_RERUN_FAILURES_DELAY }}
           -m "${{ env.PYTEST_MARKER }}"
 
       # CONDA-RATTLER-SOLVER CHANGE
@@ -637,7 +643,7 @@ jobs:
           python -m pip install -e ../conda/ --no-deps
           python -m conda init --all
           . $CONDA_PREFIX/etc/profile.d/conda.sh
-          python -m pytest -vv -m "not slow" --reruns=${{ env.PYTEST_RERUN_FAILURES }} --durations=16
+          python -m pytest -vv -m "not slow" --reruns=${{ env.PYTEST_RERUN_FAILURES }} --reruns-delay ${{ env.PYTEST_RERUN_FAILURES_DELAY }} --durations=16
       #/ CONDA-RATTLER-SOLVER CHANGE
 
       - name: Upload Coverage

--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -189,8 +189,9 @@ jobs:
           --splits=${{ env.PYTEST_SPLITS }}
           --reruns=${{ env.PYTEST_RERUN_FAILURES }}
           -m "${{ env.PYTEST_MARKER }}"
+          --sw
 
-      # CONDA-LIBMAMBA-SOLVER CHANGE
+      # CONDA-RATTLER-SOLVER CHANGE
       - name: Run conda-rattler-solver Tests
         working-directory: conda-rattler-solver
         if: ${{ matrix.test-type == 'conda-rattler-solver' }}
@@ -199,8 +200,8 @@ jobs:
           python -m pip install -e ../conda/ --no-deps
           python -m conda init --all
           . $CONDA_PREFIX/etc/profile.d/conda.sh
-          python -m pytest -vv -m "not slow" --reruns=${{ env.PYTEST_RERUN_FAILURES }} --durations=16
-      #/ CONDA-LIBMAMBA-SOLVER CHANGE
+          python -m pytest -vv -m "not slow" --reruns=${{ env.PYTEST_RERUN_FAILURES }} --durations=16 --sw
+      #/ CONDA-RATTLER-SOLVER CHANGE
 
       - name: Upload Coverage
         uses: codecov/codecov-action@v4

--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -30,7 +30,7 @@ concurrency:
   cancel-in-progress: true
 
 env:
-  PYTEST_RERUN_FAILURES: 0
+  PYTEST_RERUN_FAILURES: 2
   # See https://github.com/conda/conda/pull/13694
   # we can't break classic from here; no need to test it
   # those tests will still be available for local debugging if necessary

--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -516,8 +516,8 @@ jobs:
       matrix:
         # test lower version (w/ osx-64 & defaults & unit tests) and upper version (w/ osx-arm64 & conda-forge & integration tests)
         arch: [osx-64, osx-arm64]
-        python-version: ['3.10']  # ['3.8', '3.11']
-        default-channel: [conda-forge]  #[defaults, conda-forge]
+        python-version: ['3.9', '3.11']
+        default-channel: [defaults, conda-forge]
         test-type: [conda-rattler-solver, unit, integration]  # CONDA-RATTLER-SOLVER CHANGE
         test-group: [1, 2, 3]
         exclude:
@@ -528,7 +528,7 @@ jobs:
           - arch: osx-64
             test-type: integration
           - arch: osx-arm64
-            python-version: '3.8'
+            python-version: '3.9'
           - arch: osx-arm64
             default-channel: defaults
           - arch: osx-arm64
@@ -541,6 +541,8 @@ jobs:
             test-group: 2  # CONDA-RATTLER-SOLVER CHANGE
           - test-type: conda-rattler-solver  # CONDA-RATTLER-SOLVER CHANGE
             test-group: 3  # CONDA-RATTLER-SOLVER CHANGE
+          - test-type: conda-rattler-solver  # CONDA-RATTLER-SOLVER CHANGE
+            default-channel: defaults  # CONDA-RATTLER-SOLVER CHANGE
     env:
       PYTEST_MARKER: ${{ matrix.test-type == 'unit' && 'not integration' || 'integration' }}
       PYTEST_SPLITS: ${{ matrix.test-type == 'unit' && '2' || '3' }}
@@ -601,6 +603,11 @@ jobs:
       - name: Install conda-rattler-solver
         run: python -m pip install -e conda-rattler-solver/ -vv --no-deps
       #/ CONDA-RATTLER-SOLVER CHANGE
+
+      - name: Setup Shells
+        # for tests/shell, so only necessary for integration tests
+        if: matrix.test-type == 'integration'
+        run: brew update && brew install fish xonsh
 
       - name: Conda Info
         run: python -m conda info --verbose

--- a/conda_rattler_solver/index.py
+++ b/conda_rattler_solver/index.py
@@ -277,5 +277,7 @@ class RattlerIndexHelper:
         return conda_records
 
     def __del__(self):
-        for path in self._unlink_on_del:
-            path.unlink(missing_ok=True)
+        if self._unlink_on_del:
+            self._index.clear()
+            for path in self._unlink_on_del:
+                path.unlink(missing_ok=True)

--- a/conda_rattler_solver/index.py
+++ b/conda_rattler_solver/index.py
@@ -63,7 +63,6 @@ class RattlerIndexHelper:
                 {info.noauth_url: info for info in self._load_pkgs_cache(pkgs_dirs)}
             )
 
-
     @classmethod
     def from_platform_aware_channel(cls, channel: Channel) -> Self:
         if not channel.platform:

--- a/conda_rattler_solver/index.py
+++ b/conda_rattler_solver/index.py
@@ -16,7 +16,6 @@ import rattler
 from conda.base.constants import REPODATA_FN
 from conda.base.context import context
 from conda.common.io import DummyExecutor, ThreadLimitedThreadPoolExecutor
-from conda.common.path import url_to_path
 from conda.common.serialize import json_dump
 from conda.common.url import path_to_url, remove_auth, split_anaconda_token
 from conda.core.package_cache_data import PackageCacheData
@@ -278,6 +277,8 @@ class RattlerIndexHelper:
         return conda_records
 
     def __del__(self):
+        if self._unlink_on_del:
+            self._index.clear()
         for path in self._unlink_on_del:
             try:
                 path.unlink(missing_ok=True)

--- a/conda_rattler_solver/index.py
+++ b/conda_rattler_solver/index.py
@@ -74,7 +74,8 @@ class RattlerIndexHelper:
         self._subdirs = context.subdirs if subdirs is None else subdirs
         self._repodata_fn = repodata_fn
 
-        self._index = self._load_channels()
+        self._index = {}
+        self._index.update(self._load_channels())
         if pkgs_dirs:
             self._index.update(
                 {info.noauth_url: info for info in self._load_pkgs_cache(pkgs_dirs)}

--- a/conda_rattler_solver/index.py
+++ b/conda_rattler_solver/index.py
@@ -125,9 +125,6 @@ class RattlerIndexHelper:
         return self._index[key]
 
     def _fetch_channel(self, url: str) -> tuple[str, os.PathLike]:
-        if url.startswith("file://"):
-            return url, f"{url_to_path(url)}{os.path.sep}{self._repodata_fn}"
-
         channel = Channel.from_url(url)
         if not channel.subdir:
             raise ValueError(f"Channel URLs must specify a subdir! Provided: {url}")

--- a/conda_rattler_solver/index.py
+++ b/conda_rattler_solver/index.py
@@ -235,7 +235,7 @@ class RattlerIndexHelper:
         # 2. Fetch URLs (if needed)
         Executor = (
             DummyExecutor
-            if context.debug or context.repodata_threads == 1
+            if context.debug or context.repodata_threads == 1 or sys.platform == "win32"
             else partial(ThreadLimitedThreadPoolExecutor, max_workers=context.repodata_threads)
         )
         with Executor() as executor:

--- a/conda_rattler_solver/index.py
+++ b/conda_rattler_solver/index.py
@@ -51,6 +51,8 @@ class RattlerIndexHelper:
         repodata_fn: str = REPODATA_FN,
         pkgs_dirs: PathsType = (),
     ):
+        self._unlink_on_del: list[Path] = []
+
         self._channels = context.channels if channels is None else channels
         self._subdirs = context.subdirs if subdirs is None else subdirs
         self._repodata_fn = repodata_fn
@@ -61,7 +63,6 @@ class RattlerIndexHelper:
                 {info.noauth_url: info for info in self._load_pkgs_cache(pkgs_dirs)}
             )
 
-        self._unlink_on_del: list[Path] = []
 
     @classmethod
     def from_platform_aware_channel(cls, channel: Channel) -> Self:

--- a/conda_rattler_solver/solver.py
+++ b/conda_rattler_solver/solver.py
@@ -186,7 +186,7 @@ class RattlerSolver(Solver):
             )
         else:
             return (
-                f"Channel: {"".join(canonical_names)}\n"
+                f"Channel: {''.join(canonical_names)}\n"
                 f"Platform: {context.subdir}\n"
                 f"Target prefix: {self.prefix}\n"
                 f"Collecting package metadata ({self._repodata_fn})"

--- a/conda_rattler_solver/solver.py
+++ b/conda_rattler_solver/solver.py
@@ -671,7 +671,7 @@ class RattlerSolver(Solver):
 
     def _match_spec_to_rattler_match_spec(self, spec: MatchSpec) -> rattler.MatchSpec:
         match_spec = MatchSpec(spec)
-        if "/" in match_spec.name:
+        if os.sep in match_spec.name or "/" in match_spec.name:
             raise InvalidMatchSpec(match_spec, "Cannot contain slashes.")
         return rattler.MatchSpec(str(match_spec).rstrip("=").replace("=[", "["))
 

--- a/conda_rattler_solver/solver.py
+++ b/conda_rattler_solver/solver.py
@@ -23,13 +23,13 @@ from conda.exceptions import InvalidMatchSpec, PackagesNotFoundError
 from conda.models.channel import Channel
 from conda.models.match_spec import MatchSpec
 from conda.reporters import get_spinner
-from conda_libmamba_solver.state import SolverInputState, SolverOutputState
 from rattler import __version__ as rattler_version
 from rattler.exceptions import SolverError as RattlerSolverError
 
 from . import __version__
 from .exceptions import RattlerUnsatisfiableError
 from .index import RattlerIndexHelper
+from .state import SolverInputState, SolverOutputState
 from .utils import (
     fix_version_field_for_conda_build,
     maybe_ignore_current_repodata,
@@ -175,13 +175,22 @@ class RattlerSolver(Solver):
             return msg
 
         canonical_names = list(dict.fromkeys([c.canonical_name for c in channels]))
-        canonical_names_dashed = "\n - ".join(canonical_names)
-        return (
-            f"Channels:\n"
-            f" - {canonical_names_dashed}\n"
-            f"Platform: {context.subdir}\n"
-            f"Collecting package metadata ({self._repodata_fn})"
-        )
+        if len(canonical_names) > 1:
+            canonical_names_dashed = "\n - ".join(canonical_names)
+            return (
+                f"Channels:\n"
+                f" - {canonical_names_dashed}\n"
+                f"Platform: {context.subdir}\n"
+                f"Target prefix: {self.prefix}\n"
+                f"Collecting package metadata ({self._repodata_fn})"
+            )
+        else:
+            return (
+                f"Channel: {"".join(canonical_names)}\n"
+                f"Platform: {context.subdir}\n"
+                f"Target prefix: {self.prefix}\n"
+                f"Collecting package metadata ({self._repodata_fn})"
+            )
 
     def _collect_channel_list(self, in_state: SolverInputState) -> list[Channel]:
         # Aggregate channels and subdirs

--- a/conda_rattler_solver/solver.py
+++ b/conda_rattler_solver/solver.py
@@ -649,7 +649,9 @@ class RattlerSolver(Solver):
         # TODO: This is a hack to get the installed packages into the solver
         # but rattler doesn't allow PrefixRecords to be built through the API yet
         with NamedTemporaryFile(suffix=".json", mode="w", delete=False) as tmp:
-            json.dump(record.dump(), tmp)
+            data = record.dump()
+            data.setdefault("url", "https://this.package/does-not-have-a-url")
+            json.dump(data, tmp)
         try:
             return rattler.PrefixRecord.from_path(tmp.name)
         finally:

--- a/conda_rattler_solver/utils.py
+++ b/conda_rattler_solver/utils.py
@@ -2,12 +2,10 @@ from __future__ import annotations
 
 import json
 import os
-import random
 import re
 import sys
 from contextlib import suppress
 from logging import getLogger
-from string import hexdigits
 from textwrap import dedent
 from typing import TYPE_CHECKING
 
@@ -283,7 +281,3 @@ def fix_version_field_for_conda_build(spec: MatchSpec) -> MatchSpec:
                 spec_fields[1] = version_str + "*"
             return MatchSpec(" ".join(spec_fields))
     return spec
-
-
-def random_hex(length: int = 7) -> str:
-    return "".join(random.choices(hexdigits, k=length))

--- a/conda_rattler_solver/utils.py
+++ b/conda_rattler_solver/utils.py
@@ -2,10 +2,12 @@ from __future__ import annotations
 
 import json
 import os
+import random
 import re
 import sys
 from contextlib import suppress
 from logging import getLogger
+from string import hexdigits
 from textwrap import dedent
 from typing import TYPE_CHECKING
 
@@ -281,3 +283,7 @@ def fix_version_field_for_conda_build(spec: MatchSpec) -> MatchSpec:
                 spec_fields[1] = version_str + "*"
             return MatchSpec(" ".join(spec_fields))
     return spec
+
+
+def random_hex(length: int = 6) -> str:
+    return random.choice(hexdigits, length)

--- a/conda_rattler_solver/utils.py
+++ b/conda_rattler_solver/utils.py
@@ -286,4 +286,4 @@ def fix_version_field_for_conda_build(spec: MatchSpec) -> MatchSpec:
 
 
 def random_hex(length: int = 6) -> str:
-    return random.choice(hexdigits, length)
+    return random.choices(hexdigits, length)

--- a/conda_rattler_solver/utils.py
+++ b/conda_rattler_solver/utils.py
@@ -285,5 +285,5 @@ def fix_version_field_for_conda_build(spec: MatchSpec) -> MatchSpec:
     return spec
 
 
-def random_hex(length: int = 6) -> str:
-    return random.choices(hexdigits, length)
+def random_hex(length: int = 7) -> str:
+    return "".join(random.choices(hexdigits, k=length))

--- a/tests/test_solver_differences.py
+++ b/tests/test_solver_differences.py
@@ -9,6 +9,9 @@ workarounds or didn't meet users' expectations... specially if compared to conda
 import json
 import os
 
+import pytest
+from conda.common.compat import on_linux
+
 from .repodata_time_machine import repodata_time_machine
 from .utils import conda_subprocess
 
@@ -156,6 +159,7 @@ def test_gpu_cpu_mutexes():
     assert not next((pkg for pkg in data["actions"]["LINK"] if pkg["name"] == "cudatoolkit"), None)
 
 
+@pytest.mark.skipif(not on_linux, reason="Slow. Running on Linux only.")
 def test_old_panel(tmp_path):
     """
     https://github.com/conda/conda-libmamba-solver/issues/64

--- a/tests/test_workarounds.py
+++ b/tests/test_workarounds.py
@@ -66,7 +66,7 @@ def test_build_string_filters():
 
 @pytest.mark.parametrize("stage", ["Collecting package metadata", "Solving environment"])
 def test_ctrl_c(stage):
-    TIMEOUT = 15  # Used twice in total, so account for double the amount
+    TIMEOUT = 30 if on_win else 15  # Used twice in total, so account for double the amount
     p = sp.Popen(
         [
             sys.executable,


### PR DESCRIPTION
There are some errors on Windows, not reproducible locally. There's some race condition where some repodata file handles are left open, so for now we'll always create a copy before opening _if_ we are running the CI test suite on Windows. There are probably better solutions but this is will work for now.