### PR TITLE
Do not report "not found" packages as missing if already installed

### DIFF
--- a/conda_rattler_solver/solver.py
+++ b/conda_rattler_solver/solver.py
@@ -364,7 +364,7 @@ class RattlerSolver(Solver):
                 )
             )
         except RattlerSolverError as exc:
-            self._maybe_raise_for_problems(str(exc), out_state)
+            self._maybe_raise_for_problems(str(exc), in_state, out_state)
             return exc
         else:
             out_state.conflicts.clear()
@@ -558,7 +558,9 @@ class RattlerSolver(Solver):
 
     # region Error reporting
 
-    def _maybe_raise_for_problems(self, problems: str, out_state: SolverOutputState):
+    def _maybe_raise_for_problems(
+        self, problems: str, in_state: SolverInputState, out_state: SolverOutputState
+    ):
         unsatisfiable = {}
         not_found = {}
         for line in problems.splitlines():
@@ -586,7 +588,14 @@ class RattlerSolver(Solver):
                 position = line.index("No candidates were found for ")
                 position += len("No candidates were found for ")
                 spec = line[position:].rstrip(".")
-                not_found[spec.split()[0]] = MatchSpec(spec)
+                spec = MatchSpec(spec)
+                # Do not consider "not found" if it's already installed; this happens
+                # when user requested a package from a channel that is no longer in the
+                # list. e.g. `conda create main::psutil` + `conda install -c conda-forge python`
+                if any(spec.match(record) for record in in_state.installed.values()):
+                    unsatisfiable[spec.name] = spec
+                else:
+                    not_found[spec.name] = spec
         if not unsatisfiable and not_found:
             log.debug(
                 "Inferred PackagesNotFoundError %s from conflicts:\n%s",


### PR DESCRIPTION
Do not consider "not found" if it's already installed. Otherwise we would raise `PackagesNotFoundError` too early.

This can happen when the user requested a package from a channel that is no longer in the list. e.g. `conda create main::psutil` + `conda install --override-channels -c conda-forge python` would complain about `main::psutil` not being available because it doesn't match `psutil` in `main`. By marking it as conflicting, the solver loop will relax it.          