### PR TITLE
Bump setup-miniconda and remove xonsh workarounds

### DIFF
--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -166,7 +166,6 @@ jobs:
           --file tests\requirements-${{ runner.os }}.txt
           --file tests\requirements-ci.txt
           --file tests\requirements-s3.txt
-          --file tests\requirements-truststore.txt
           --file ..\conda-rattler-solver\dev\requirements.txt
           --file ..\conda-rattler-solver\tests\requirements.txt
           python=${{ matrix.python-version }}
@@ -343,7 +342,6 @@ jobs:
           --file tests/requirements-${{ runner.os }}.txt
           --file tests/requirements-ci.txt
           --file tests/requirements-s3.txt
-          --file tests/requirements-truststore.txt
           --file ../conda-rattler-solver/dev/requirements.txt
           --file ../conda-rattler-solver/tests/requirements.txt
           python=${{ matrix.python-version }}
@@ -501,7 +499,6 @@ jobs:
           --file tests/requirements.txt
           --file tests/requirements-ci.txt
           --file tests/requirements-s3.txt
-          --file tests/requirements-truststore.txt
           --file ../conda-rattler-solver/dev/requirements.txt
           --file ../conda-rattler-solver/tests/requirements.txt
           python=${{ matrix.python-version }}


### PR DESCRIPTION
Also bumped other actions as a side effect of running `gha-update`.