### PR TITLE
Update `legacy_bz2_size` to integer type

### DIFF
--- a/conda_rattler_solver/utils.py
+++ b/conda_rattler_solver/utils.py
@@ -127,7 +127,7 @@ def conda_prefix_record_to_rattler_prefix_record(
         size=record.get("size"),
         features=record.get("features") or None,
         legacy_bz2_md5=bytes.fromhex(record.get("legacy_bz2_md5", "") or "") or None,
-        legacy_bz2_size=int(record.get("legacy_bz2_size", 0)),
+        legacy_bz2_size=record.get("legacy_bz2_size", 0),
         license=record.get("license"),
         license_family=record.get("license_family"),
         python_site_packages_path=record.get("python_site_packages_path"),


### PR DESCRIPTION
Change legacy_bz2_size to avoid fromhex()

Does it need a type coercion at all?