### PR TITLE
Fix tests - conda raises PackagesNotFoundInChannelsError

### DIFF
--- a/tests/test_solver.py
+++ b/tests/test_solver.py
@@ -321,7 +321,7 @@ def test_pinned_with_cli_build_string(tmp_env: TmpEnvFixture) -> None:
         )
         data = json.loads(p.stdout)
         assert not data.get("success")
-        assert data["exception_name"] == "PackagesNotFoundError"
+        assert data["exception_name"] == "PackagesNotFoundInChannelsError"
 
 
 def test_constraining_pin_and_requested():


### PR DESCRIPTION
This is added in
[v26.3.0](https://github.com/conda/conda/blob/main/CHANGELOG.md#2630-2026-03-30) of conda to distinguish between when package is not found in a channel versus in a prefix.