### PR TITLE
Build and upload noarch packages

### DIFF
--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -706,7 +706,7 @@ jobs:
           _CONDA_BUILD_ISOLATED_ACTIVATION: 1
         with:
           package-name: ${{ github.event.repository.name }}
-          subdir: ${{ matrix.subdir }}
+          subdir: noarch
           anaconda-org-channel: conda-canary
           anaconda-org-label: ${{ env.ANACONDA_ORG_LABEL }}
           anaconda-org-token: ${{ secrets.ANACONDA_ORG_CONDA_CANARY_TOKEN }}


### PR DESCRIPTION
conda-rattler-solver is a noarch package. This should be reflected in the canary-release gha so that it may [find the built package](https://github.com/conda/actions/blob/main/canary-release/action.yml#L98). 