### PR TITLE
CI: upgrade c-l-s in base before test deps install

### DIFF
--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -153,6 +153,11 @@ jobs:
           pkgs-dirs: D:\conda_pkgs_dir
           installation-dir: D:\conda
 
+      # Workaround: miniforge ships c-l-s 26.4.0 which has a sqlite locking bug.
+      # Remove once miniforge ships c-l-s >=26.4.1.
+      - name: Upgrade conda-libmamba-solver
+        run: conda install -n base --yes "conda-libmamba-solver>=26.4.1"
+
       - name: Conda Install
         working-directory: conda  # CONDA-RATTLER-SOLVER CHANGE
         # CONDA-RATTLER-SOLVER CHANGE: add conda-rattler-solver requirements.txt
@@ -329,6 +334,11 @@ jobs:
           condarc-file: conda/.github/condarc-${{ matrix.default-channel }}
           run-post: false  # skip post cleanup
 
+      # Workaround: miniforge ships c-l-s 26.4.0 which has a sqlite locking bug.
+      # Remove once miniforge ships c-l-s >=26.4.1.
+      - name: Upgrade conda-libmamba-solver
+        run: conda install -n base --yes "conda-libmamba-solver>=26.4.1"
+
       - name: Conda Install
         working-directory: conda
         run: conda install
@@ -482,6 +492,11 @@ jobs:
           run-post: false  # skip post cleanup
           miniconda-version: ${{ matrix.default-channel == 'defaults' && 'latest' || null }}
           miniforge-version: ${{ matrix.default-channel == 'conda-forge' && 'latest' || null }}
+
+      # Workaround: miniforge ships c-l-s 26.4.0 which has a sqlite locking bug.
+      # Remove once miniforge ships c-l-s >=26.4.1.
+      - name: Upgrade conda-libmamba-solver
+        run: conda install -n base --yes "conda-libmamba-solver>=26.4.1"
 
       - name: Conda Install
         working-directory: conda # CONDA-RATTLER-SOLVER CHANGE


### PR DESCRIPTION
### Description

Miniforge ships c-l-s 26.4.0 which has a sqlite locking bug (`database is locked` during concurrent shard cache access). The `conda install` step for test dependencies uses the base solver and crashes.

This adds `conda install -n base --yes "conda-libmamba-solver>=26.4.1"` after each Setup Miniconda step, matching the same workaround applied to conda/conda in conda/conda#16097.

Remove once miniforge ships c-l-s >=26.4.1 (conda-forge/miniforge#878).

Refs: conda/conda#16083

### Checklist - did you ...

- [x] ~Add a file to the `news` directory~ Not applicable -- CI-only change.
- [x] ~Add / update necessary tests?~ Not applicable.
- [x] ~Add / update outdated documentation?~ Not applicable.