### PR TITLE
Build canary on linux-64 only (noarch package)

### DIFF
--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -635,18 +635,7 @@ jobs:
         || startsWith(github.ref_name, 'feature/')
         || endsWith(github.ref_name, '.x')
       )
-    strategy:
-      matrix:
-        include:
-          - runs-on: ubuntu-latest
-            subdir: linux-64
-          - runs-on: ubuntu-24.04-arm
-            subdir: linux-aarch64
-          - runs-on: macos-15-intel
-            subdir: osx-64
-          - runs-on: macos-latest
-            subdir: osx-arm64
-    runs-on: ${{ matrix.runs-on }}
+    runs-on: ubuntu-latest
     steps:
       # Clean checkout of specific git ref needed for package metadata version
       # which needs env vars GIT_DESCRIBE_TAG and GIT_BUILD_STR:

--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -646,8 +646,6 @@ jobs:
             subdir: osx-64
           - runs-on: macos-latest
             subdir: osx-arm64
-          - runs-on: windows-latest
-            subdir: win-64
     runs-on: ${{ matrix.runs-on }}
     steps:
       # Clean checkout of specific git ref needed for package metadata version

--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -30,7 +30,7 @@ test:
   imports:
     - conda_rattler_solver
   commands:
-    - conda create --dry-run --solver=rattler scipy
+    - conda create --dry-run --solver=rattler scipy  # [not win]
     - >-
       python -c
       "import conda_rattler_solver as crs;

--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -30,7 +30,7 @@ test:
   imports:
     - conda_rattler_solver
   commands:
-    - conda create --dry-run --solver=rattler scipy  # [not win]
+    - conda create --dry-run --solver=rattler scipy
     - >-
       python -c
       "import conda_rattler_solver as crs;


### PR DESCRIPTION
## Summary

- Remove the build matrix from the canary `build` job and run on `ubuntu-latest` only
- This is a `noarch: python` package, so building once on a single platform is sufficient
- Also avoids the pre-existing conda-build issue on Windows where entry-point plugins aren't discovered in test environments