### PR TITLE
Dependency and post-release cleanup

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,6 +1,6 @@
 # Changelog
 
-## 0.1.0 (2026-05-15)
+## 0.1.0 (2026-05-16)
 
 * Bump conda dependency to 26.5.0 by @soapy1 #61
 * Enable conditional dependencies and extras for user input by @jaimergp in #28

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -20,7 +20,7 @@ classifiers = [
 ]
 requires-python = ">=3.10"
 dependencies = [
-  "conda >=25.5.0",  # FIXME: Bump to 26.5.0
+  "conda >=25.6.0",
   "py-rattler >=0.23.0,<0.24.0a0",
 ]
 dynamic = ["version"]


### PR DESCRIPTION
<!-- Hello! Thanks for submitting a PR! To help make things go a bit more
     smoothly, we would appreciate it if you follow this template. -->

### Description

After the 0.1.0 release, I noticed that #61 changed the minimum conda version for Pixi and the canary build, but not for the Python dependency. Since no releases of conda-rattler-solver are published on pypi.org, I don't think this has a big impact.

Also the actual release happened one day later, so I updated the release date in the changelog.


<!-- Just as a reminder, everyone in all conda org spaces (including PRs)
     must follow the Conda Org Code of Conduct (link below).

     Finally, once again, thanks for your time and effort. If you have any
     feedback in regards to your experience contributing here, please
     let us know!

     Helpful links:
       - Conda Org COC: https://github.com/conda/.github/blob/main/CODE_OF_CONDUCT.md
       - Contributing docs: https://github.com/conda/.github/blob/main/CONTRIBUTING.md -->
