### PR TITLE
Fix conda runtime dependency version

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -20,7 +20,7 @@ classifiers = [
 ]
 requires-python = ">=3.10"
 dependencies = [
-  "conda >=25.6.0",
+  "conda >=26.5.0",
   "py-rattler >=0.23.0,<0.24.0a0",
 ]
 dynamic = ["version"]


### PR DESCRIPTION
## Summary
- set the package runtime dependency to `conda >=26.5.0`
- align `[project].dependencies` with pixi, the conda-build recipe, dev requirements, and the 0.1.0 changelog

## Testing
- `python3 -c 'import pathlib, tomllib; data=tomllib.loads(pathlib.Path("pyproject.toml").read_text()); print(data["project"]["dependencies"][0]); print(data["tool"]["pixi"]["dependencies"]["conda"])'`
- `git diff --check`