### PR TITLE
solver.py: Raise the exception in conda-build if needed

### DIFF
--- a/conda_rattler_solver/solver.py
+++ b/conda_rattler_solver/solver.py
@@ -657,6 +657,13 @@ class RattlerSolver(Solver):
                     unsatisfiable[spec.name] = spec
                 else:
                     not_found[spec.name] = spec
+
+        # Raise the exception for conda-build if needed
+        self._maybe_raise_for_conda_build(
+            {**unsatisfiable, **not_found},
+            message=problems,
+        )
+
         if not unsatisfiable and not_found:
             log.debug(
                 "Inferred PackagesNotFoundError %s from conflicts:\n%s",


### PR DESCRIPTION
If we don't do this conda-build can run into errors if it doesn't receive the correct exception type. This caused many test failures when running conda-build test suite with rattler solver in https://github.com/conda/conda-build/pull/5989

<!-- Hello! Thanks for submitting a PR! To help make things go a bit more
     smoothly, we would appreciate it if you follow this template. -->

### Description

<!-- Good things to put here include:
       - reasons for the change (please link any relevant issues!),
       - any noteworthy (or hacky) choices to be aware of,
       - or what the problem resolved here looked like. -->



<!-- Just as a reminder, everyone in all conda org spaces (including PRs)
     must follow the Conda Org Code of Conduct (link below).

     Finally, once again, thanks for your time and effort. If you have any
     feedback in regards to your experience contributing here, please
     let us know!

     Helpful links:
       - Conda Org COC: https://github.com/conda/.github/blob/main/CODE_OF_CONDUCT.md
       - Contributing docs: https://github.com/conda/.github/blob/main/CONTRIBUTING.md -->
