### PR TITLE
Fix tests downgrading Python to 3.9 breaks pip

### DIFF
--- a/news/78-fix-python-downgrade-test
+++ b/news/78-fix-python-downgrade-test
@@ -1,0 +1,3 @@
+### Other
+
+* Fix integration test: downgrading to Python 3.9 breaks `pip --version` on current pip. (#78)

--- a/news/fix-python-downgrade-test
+++ b/news/fix-python-downgrade-test
@@ -1,0 +1,3 @@
+### Other
+
+* Fix integration test: downgrading to Python 3.9 breaks `pip --version` on current pip (unrelated to rattler). Use 3.11→3.10, matching conda-libmamba-solver.

--- a/news/fix-python-downgrade-test
+++ b/news/fix-python-downgrade-test
@@ -1,3 +1,0 @@
-### Other
-
-* Fix integration test: downgrading to Python 3.9 breaks `pip --version` on current pip (unrelated to rattler). Use 3.11→3.10, matching conda-libmamba-solver.

--- a/tests/test_channels.py
+++ b/tests/test_channels.py
@@ -43,7 +43,7 @@ def test_channel_matchspec(conda_cli: CondaCLIFixture, path_factory: PathFactory
         "--override-channels",
         "--channel=defaults",
         "conda-forge::libblas=*=*openblas",
-        "python=3.9",
+        "python=3.10",
     )
     result = json.loads(stdout)
     assert result["success"] is True

--- a/tests/test_performance.py
+++ b/tests/test_performance.py
@@ -117,7 +117,7 @@ def test_install_vaex_from_conda_forge_and_defaults(conda_cli: CondaCLIFixture) 
         "create",
         "--dry-run",
         *_channels_as_args(["conda-forge", "defaults"]),
-        "python=3.9",
+        "python=3.10",
         "vaex",
         raises=DryRunExit,
     )

--- a/tests/test_solver.py
+++ b/tests/test_solver.py
@@ -503,7 +503,7 @@ def test_python_downgrade_with_pins_removes_truststore(tmp_env: TmpEnvFixture) -
                 *solver,
                 "--dry-run",
                 "--json",
-                "python=3.9",
+                "python=3.10",
                 env=env,
                 check=False,
             )
@@ -513,7 +513,7 @@ def test_python_downgrade_with_pins_removes_truststore(tmp_env: TmpEnvFixture) -
             assert data.get("dry_run")
             link_dict = {pkg["name"]: pkg for pkg in data["actions"]["LINK"]}
             unlink_dict = {pkg["name"]: pkg for pkg in data["actions"]["UNLINK"]}
-            assert link_dict["python"]["version"].startswith("3.9.")
+            assert link_dict["python"]["version"].startswith("3.10.")
             assert "truststore" in unlink_dict
             if pin:
                 # shouldn't have changed!

--- a/tests/test_solver.py
+++ b/tests/test_solver.py
@@ -83,9 +83,9 @@ def test_python_downgrade_reinstalls_noarch_packages(
         "--channel=conda-forge",
         "--solver=rattler",
         "pip",
-        "python=3.10",
+        "python=3.11",
     ) as prefix:
-        assert PrefixData(prefix).get("python").version.startswith("3.10")
+        assert PrefixData(prefix).get("python").version.startswith("3.11")
         if on_win:
             pip = str(prefix / "Scripts" / "pip.exe")
         else:
@@ -98,9 +98,11 @@ def test_python_downgrade_reinstalls_noarch_packages(
             "--solver=rattler",
             "--override-channels",
             "--channel=conda-forge",
-            "python=3.9",
+            "python=3.10",
             "--yes",
         )
+        PrefixData._cache_.clear()
+        assert PrefixData(prefix).get("python").version.startswith("3.10")
         check_call([pip, "--version"])
 
 
@@ -332,7 +334,7 @@ def test_pinned_with_cli_build_string(tmp_env: TmpEnvFixture) -> None:
 
 def test_constraining_pin_and_requested():
     env = os.environ.copy()
-    env["CONDA_PINNED_PACKAGES"] = "python=3.9"
+    env["CONDA_PINNED_PACKAGES"] = "python=3.10"
 
     # This should fail because it contradicts the pinned packages
     p = conda_subprocess(
@@ -341,7 +343,7 @@ def test_constraining_pin_and_requested():
         "unused",
         "--dry-run",
         "--json",
-        "python=3.10",
+        "python=3.11",
         "--override-channels",
         "-c",
         "conda-forge",

--- a/tests/test_solver_differences.py
+++ b/tests/test_solver_differences.py
@@ -117,7 +117,7 @@ def test_gpu_cpu_mutexes():
     pkgs = (
         "cpuonly",
         "pyg=2.1.0",
-        "python=3.9",
+        "python=3.10",
         "pytorch::pytorch=1.12",
     )
     env = os.environ.copy()
@@ -159,7 +159,7 @@ def test_gpu_cpu_mutexes():
         "--solver=rattler",
         "cpuonly",
         "pyg=2.1.0",
-        "python=3.9",
+        "python=3.10",
         "pytorch::pytorch",  # more recent pytorch versions seem to be properly packaged
         env=env,
     )


### PR DESCRIPTION
<!-- Hello! Thanks for submitting a PR! To help make things go a bit more
     smoothly, we would appreciate it if you follow this template. -->

### Description

I noticed in https://github.com/AnacondaRecipes/conda-rattler-solver-feedstock/pull/7 which is a feedstock update to version 0.1.1, that one of the tests was failing with the following error:

```
lib/python3.10/site-packages/pip/_internal/models/scheme.py", line 13, in <module>
    @dataclass(frozen=True, slots=True)
TypeError: dataclass() got an unexpected keyword argument 'slots'
```

This is similar to the fix done in https://github.com/conda/conda-libmamba-solver/pull/747 which downgrades Python from 3.11 to 3.10, instead of 3.10 to 3.9. I also updated the other tests to use 3.10 instead of 3.9 in a few other instances.

### Checklist - did you ...

<!-- If any of the following items aren't relevant to your contribution,
     please either tick them or use ~strikethrough~ so we know you've gone
     through the checklist. -->

- [X] Add a file to the `news` directory ([using the template](https://github.com/conda/conda-rattler-solver/blob/main/news/TEMPLATE)) for the next release's release notes?
     <!-- All "significant" changes should get an entry:
            - user-facing changes or enhancements
            - bug fixes
            - deprecations
            - documentation updates
            - etc -->
- [X] Add / update necessary tests?
- [ ] ~Add / update outdated documentation?~


<!-- Just as a reminder, everyone in all conda org spaces (including PRs)
     must follow the Conda Org Code of Conduct (link below).

     Finally, once again, thanks for your time and effort. If you have any
     feedback in regards to your experience contributing here, please
     let us know!

     Helpful links:
       - Conda Org COC: https://github.com/conda/conda-rattler-solver/blob/main/CODE_OF_CONDUCT.md
       - Contributing docs: https://github.com/conda/conda-rattler-solver/blob/main/CONTRIBUTING.md -->
