### PR TITLE
Enable infrastructure-managed Dependabot config

### DIFF
--- a/.github/template-files/config.yml
+++ b/.github/template-files/config.yml
@@ -40,8 +40,14 @@ conda/infrastructure:
     dst: .github/PULL_REQUEST_TEMPLATE.md
 
   # [optional] dependabot — pick ONE variant
+  # - src: templates/dependabot/github-actions.yml
+  #   dst: .github/dependabot.yml
   - src: templates/dependabot/github-actions-with-pre-commit.yml
     dst: .github/dependabot.yml
+  # - src: templates/dependabot/github-actions-with-docs-pip.yml
+  #   dst: .github/dependabot.yml
+  # - src: templates/dependabot/github-actions-full.yml
+  #   dst: .github/dependabot.yml
 
   # [optional] rever release files
   # Select one of the following:

--- a/.github/template-files/config.yml
+++ b/.github/template-files/config.yml
@@ -39,6 +39,10 @@ conda/infrastructure:
   - src: templates/pull_requests/base.md
     dst: .github/PULL_REQUEST_TEMPLATE.md
 
+  # [optional] dependabot — pick ONE variant
+  - src: templates/dependabot/github-actions-with-pre-commit.yml
+    dst: .github/dependabot.yml
+
   # [optional] rever release files
   # Select one of the following:
   # conda and conda-build release file or

--- a/news/84-infrastructure-dependabot
+++ b/news/84-infrastructure-dependabot
@@ -1,0 +1,19 @@
+### Enhancements
+
+* <news item>
+
+### Bug fixes
+
+* <news item>
+
+### Deprecations
+
+* <news item>
+
+### Docs
+
+* <news item>
+
+### Other
+
+* Enable infrastructure-managed Dependabot configuration via conda/infrastructure templates. (#84)


### PR DESCRIPTION
### Description

Enable infrastructure-managed Dependabot by adding a template-files sync entry for `templates/dependabot/github-actions-with-pre-commit.yml`.

- Variant: `github-actions-with-pre-commit`
- New: github-actions (weekly + 7-day cooldown) and pre-commit (monthly)
- Repo currently has no `dependabot.yml`

Closes #70.

Expected Dependabot behavior after sync:
- GitHub Actions: weekly, grouped, 7-day cooldown
- pre-commit: monthly, grouped

### Checklist - did you ...

- [x] Add a file to the `news` directory ([using the template](https://github.com/conda/conda-rattler-solver/blob/main/news/TEMPLATE)) for the next release's release notes?
- ~[ ] Add / update necessary tests?~
- ~[ ] Add / update outdated documentation?~
