### PR TITLE
Allow callers to provide virtual packages to solver state

### DIFF
--- a/conda_rattler_solver/state.py
+++ b/conda_rattler_solver/state.py
@@ -138,6 +138,9 @@ class SolverInputState:
     interoperability
         Whether ``PrefixData`` will also expose packages not installed by
         ``conda`` (e.g. ``pip`` and others can put Python packages in the prefix).
+    virtual_packages
+        System properties exposed to the solver. When omitted, conda detects them
+        from the local system.
     """
 
     _ENUM_STR_MAP = {
@@ -171,6 +174,7 @@ class SolverInputState:
         prune: bool | None = False,
         command: str | None = None,
         interoperability: bool | None = None,
+        virtual_packages: Iterable[PackageRecord] | None = None,
     ):
         self.prefix = prefix
         self._prefix_data = PrefixData(prefix, interoperability=interoperability)
@@ -179,7 +183,7 @@ class SolverInputState:
         self._pinned = {spec.name: spec for spec in get_pinned_specs(prefix)}
         self._aggressive_updates = {spec.name: spec for spec in context.aggressive_update_packages}
 
-        virtual = Index().system_packages
+        virtual = Index().system_packages if virtual_packages is None else virtual_packages
         self._virtual = {record.name: record for record in virtual}
 
         self._requested = {}

--- a/news/virtual-package-input-state
+++ b/news/virtual-package-input-state
@@ -1,0 +1,19 @@
+### Enhancements
+
+* Allow callers to provide virtual packages when constructing `SolverInputState`.
+
+### Bug fixes
+
+* <news item>
+
+### Deprecations
+
+* <news item>
+
+### Docs
+
+* <news item>
+
+### Other
+
+* <news item>

--- a/news/virtual-package-input-state
+++ b/news/virtual-package-input-state
@@ -1,6 +1,6 @@
 ### Enhancements
 
-* Allow callers to provide virtual packages when constructing `SolverInputState`.
+* Allow callers to provide virtual packages when constructing `SolverInputState`. (#98)
 
 ### Bug fixes
 

--- a/tests/test_state.py
+++ b/tests/test_state.py
@@ -1,0 +1,44 @@
+from __future__ import annotations
+
+import pytest
+from conda.models.records import PackageRecord
+
+import conda_rattler_solver.state as state_module
+from conda_rattler_solver.state import SolverInputState
+
+
+@pytest.mark.parametrize(
+    ("virtual_packages", "expected"),
+    [
+        pytest.param((), {}, id="empty"),
+        pytest.param(
+            (
+                PackageRecord(
+                    name="__test",
+                    version="2",
+                    build="provided",
+                    build_number=0,
+                ),
+            ),
+            {"__test": ("2", "provided")},
+            id="provided",
+        ),
+    ],
+)
+def test_solver_input_state_uses_provided_virtual_packages(
+    monkeypatch,
+    tmp_path,
+    virtual_packages,
+    expected,
+):
+    monkeypatch.setattr(
+        state_module,
+        "Index",
+        lambda: pytest.fail("local virtual packages must not be detected"),
+    )
+
+    state = SolverInputState(tmp_path, virtual_packages=virtual_packages)
+
+    assert {
+        name: (record.version, record.build) for name, record in state.virtual.items()
+    } == expected


### PR DESCRIPTION
### Description

Allow `SolverInputState` callers to provide already-resolved virtual-package records. Passing `None` preserves local detection, while an iterable—including an empty one—uses the supplied state without consulting the local system.

This lets brokered solver callers reconstruct client state without detecting and then overwriting the broker host's virtual packages.

### Checklist - did you ...

- [x] Add a file to the `news` directory for the next release's release notes?
- [x] Add / update necessary tests?
- [x] Add / update outdated documentation?
