### PR TITLE
Fix CI failures

### DIFF
--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -202,14 +202,22 @@ jobs:
           Get-Command -All powershell
           "$env:PWSHPATH" -split ";" | ForEach-Object { Get-Command -All "$_\pwsh" }
 
+      - name: Stage upstream xfail plugin
+        if: ${{ matrix.test-type != 'conda-rattler-solver' }}
+        working-directory: conda
+        shell: bash
+        run: cp ../conda-rattler-solver/tests/_pytest_upstream.py tests/_pytest_upstream.py
+
       - name: Run Upstream Tests
         # Windows is sensitive to long paths, using `--basetemp=${{ runner.temp }} to
         # keep the test directories shorter
         working-directory: conda  # CONDA-RATTLER-SOLVER CHANGE
         if: ${{ matrix.test-type != 'conda-rattler-solver' }}  # CONDA-RATTLER-SOLVER CHANGE
         # skip cli startup benchmark test - these benchmarks should only be run by conda
+        # -p: CRS-only xfails (tests/_pytest_upstream.py copied here; not packaged)
         run: >
           python -m pytest
+          -p tests._pytest_upstream
           --cov=conda
           --basetemp=${{ runner.temp }}
           --durations-path=durations\${{ runner.os }}.json
@@ -366,11 +374,18 @@ jobs:
         if: matrix.test-type == 'integration'
         run: sudo apt update && sudo apt install ash csh fish tcsh xonsh zsh
 
+      - name: Stage upstream xfail plugin
+        if: ${{ matrix.test-type != 'conda-rattler-solver' }}
+        working-directory: conda
+        run: cp ../conda-rattler-solver/tests/_pytest_upstream.py tests/_pytest_upstream.py
+
       - name: Run Tests
         working-directory: conda  # CONDA-RATTLER-SOLVER CHANGE
         if: ${{ matrix.test-type != 'conda-rattler-solver' }}  # CONDA-RATTLER-SOLVER CHANGE
         # skip cli startup benchmark test - these benchmarks should only be run by conda
+        # -p: CRS-only xfails (tests/_pytest_upstream.py copied here; not packaged)
         run: python -m pytest
+          -p tests._pytest_upstream
           --cov=conda
           --durations-path=durations/${{ runner.os }}.json
           --group=${{ matrix.test-group }}
@@ -525,12 +540,19 @@ jobs:
         if: matrix.test-type == 'integration'
         run: brew update && brew install fish xonsh
 
+      - name: Stage upstream xfail plugin
+        if: ${{ matrix.test-type != 'conda-rattler-solver' }}
+        working-directory: conda
+        run: cp ../conda-rattler-solver/tests/_pytest_upstream.py tests/_pytest_upstream.py
+
       - name: Run Tests
         working-directory: conda  # CONDA-RATTLER-SOLVER CHANGE
         if: ${{ matrix.test-type != 'conda-rattler-solver' }}  # CONDA-RATTLER-SOLVER CHANGE
         # skip cli startup benchmark test - these benchmarks should only be run by conda
+        # -p: CRS-only xfails (tests/_pytest_upstream.py copied here; not packaged)
         run: >
           python -m pytest
+          -p tests._pytest_upstream
           --cov=conda
           --durations-path=durations/${{ runner.os }}.json
           --group=${{ matrix.test-group }}

--- a/tests/_pytest_upstream.py
+++ b/tests/_pytest_upstream.py
@@ -9,7 +9,6 @@ from __future__ import annotations
 
 import pytest
 
-# https://github.com/conda/conda-rattler-solver/issues/88
 _XFAILS = {
     "tests/test_create.py::test_dont_remove_conda_dependency_with_dependent_packages[rattler]": (
         "Installed packages missing from narrowed channels: "

--- a/tests/_pytest_upstream.py
+++ b/tests/_pytest_upstream.py
@@ -1,0 +1,24 @@
+"""Pytest plugin for expected failures in conda's upstream suite under rattler.
+
+Loaded only when CRS CI runs conda's tests (copied to conda's ``tests/`` and
+loaded via ``-p tests._pytest_upstream`` in ``.github/workflows/tests.yml``).
+Use ``strict=True`` so an unexpected pass (XPASS) fails the job once the bug is fixed.
+"""
+
+from __future__ import annotations
+
+import pytest
+
+# https://github.com/conda/conda-rattler-solver/issues/88
+_XFAILS = {
+    "tests/test_create.py::test_dont_remove_conda_dependency_with_dependent_packages[rattler]": (
+        "Installed packages missing from narrowed channels: "
+        "https://github.com/conda/conda-rattler-solver/issues/88"
+    ),
+}
+
+
+def pytest_collection_modifyitems(items: list[pytest.Item]) -> None:
+    for item in items:
+        if reason := _XFAILS.get(item.nodeid):
+            item.add_marker(pytest.mark.xfail(reason=reason, strict=True))

--- a/tests/test_repoquery.py
+++ b/tests/test_repoquery.py
@@ -21,7 +21,16 @@ def test_repoquery():
     data = json.loads(p.stdout)
     assert data["result"]["status"] == "OK"
     assert len(data["result"]["pkgs"]) > 0
-    assert len([p for p in data["result"]["pkgs"] if p["name"] == "python"]) == 1
+    python = [p for p in data["result"]["pkgs"] if p["name"] == "python"]
+    # Presence is required; uniqueness is not.
+    # Duplicate `python` entries can appear when the queried package (e.g. recent
+    # conda-forge builds of conda) depends on both unconstrained `python` and a
+    # pinned `python X.Y.* *_cpython`. `repoquery depends` resolves each MatchSpec
+    # independently, so both (e.g. 3.14 and 3.10) may show up.
+    # Upstream: https://github.com/mamba-org/mamba/issues/4346
+    # Same carve-out pattern in conda-libmamba-solver tests/test_repoquery.py
+    # (https://github.com/conda/conda-libmamba-solver/pull/964).
+    assert python
 
 
 def test_query_search():


### PR DESCRIPTION
<!-- Hello! Thanks for submitting a PR! To help make things go a bit more
     smoothly, we would appreciate it if you follow this template. -->

### Description

<!-- Good things to put here include:
       - reasons for the change (please link any relevant issues!),
       - any noteworthy (or hacky) choices to be aware of,
       - or what the problem resolved here looked like. -->

CI is blocked by test failures.

Resolving by relaxing the expectations for `tests/test_repoquery.py::test_repoquery` test and marking upstream test as xfail (#88 needs resolving first).

### Checklist - did you ...

<!-- If any of the following items aren't relevant to your contribution,
     please either tick them or use ~strikethrough~ so we know you've gone
     through the checklist. -->

- [ ] ~Add a file to the `news` directory ([using the template](https://github.com/conda/conda-rattler-solver/blob/main/news/TEMPLATE)) for the next release's release notes?~
     <!-- All "significant" changes should get an entry:
            - user-facing changes or enhancements
            - bug fixes
            - deprecations
            - documentation updates
            - etc -->
- [x] Add / update necessary tests?
- [ ] ~Add / update outdated documentation?~


<!-- Just as a reminder, everyone in all conda org spaces (including PRs)
     must follow the Conda Org Code of Conduct (link below).

     Finally, once again, thanks for your time and effort. If you have any
     feedback in regards to your experience contributing here, please
     let us know!

     Helpful links:
       - Conda Org COC: https://github.com/conda/conda-rattler-solver/blob/main/CODE_OF_CONDUCT.md
       - Contributing docs: https://github.com/conda/conda-rattler-solver/blob/main/CONTRIBUTING.md -->
