### PR TITLE
Break out upstream tests into their own ci config

### DIFF
--- a/.github/workflows/test-upstream.yaml
+++ b/.github/workflows/test-upstream.yaml
@@ -1,0 +1,694 @@
+name: Test Upstream
+
+on:
+  # https://docs.github.com/en/webhooks-and-events/webhooks/webhook-events-and-payloads#push
+  push:
+    branches:
+      - main
+      - feature/**
+      - '[0-9].*.x'  # e.g., 4.14.x
+      - '[0-9][0-9].*.x'  # e.g., 23.3.x
+
+  # https://docs.github.com/en/webhooks-and-events/webhooks/webhook-events-and-payloads#pull_request
+  pull_request:
+
+  # https://docs.github.com/en/webhooks-and-events/webhooks/webhook-events-and-payloads#workflow_dispatch
+  workflow_dispatch:
+
+  # CONDA-RATTLER-SOLVER CHANGE
+  schedule:
+    - cron: "15 7 * * 1-5"  # Mon to Fri, 7:15am
+  # /CONDA-RATTLER-SOLVER CHANGE
+
+concurrency:
+  # Concurrency group that uses the workflow name and PR number if available
+  # or commit SHA as a fallback. If a new build is triggered under that
+  # concurrency group while a previous build is running it will be canceled.
+  # Repeated pushes to a PR will cancel all previous builds, while multiple
+  # merges to main will not cancel.
+  group: ${{ github.workflow }}-${{ github.event.pull_request.number || github.sha }}
+  cancel-in-progress: true
+
+env:
+  PYTEST_RERUN_FAILURES: 2
+  PYTEST_RERUN_FAILURES_DELAY: 3
+  # See https://github.com/conda/conda/pull/13694
+  # we can't break classic from here; no need to test it
+  # those tests will still be available for local debugging if necessary
+  CONDA_TEST_SOLVERS: rattler
+  CONDA_REF: main
+
+
+jobs:
+  # detect whether any code changes are included in this PR
+  changes:
+    runs-on: ubuntu-latest
+    permissions:
+      # necessary to detect changes
+      # https://github.com/dorny/paths-filter#supported-workflows
+      pull-requests: read
+    outputs:
+      code: ${{ steps.filter.outputs.code }}
+    steps:
+      - name: Checkout Source
+        uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
+        # dorny/paths-filter needs git clone for non-PR events
+        # https://github.com/dorny/paths-filter#supported-workflows
+        if: github.event_name != 'pull_request'
+
+      - name: Filter Changes
+        uses: dorny/paths-filter@de90cc6fb38fc0963ad72b210f1f284cd68cea36 # v3.0.2
+        id: filter
+        with:
+          # CONDA-RATTLER-SOLVER CHANGE
+          # changed some paths:
+          filters: |
+            code:
+              - 'conda_rattler_solver/**'
+              - '*.py'
+              - '.github/workflows/tests.yml'
+              - 'tests/**'
+              - 'pyproject.toml'
+              - 'recipe/*'
+          # /CONDA-RATTLER-SOLVER CHANGE
+
+  # windows test suite
+  windows:
+    # only run test suite if there are code changes
+    needs: changes
+    if: github.event_name == 'schedule' || needs.changes.outputs.code == 'true'
+
+    runs-on: ${{ matrix.runs-on }}
+    strategy:
+      fail-fast: false
+      matrix:
+        include:
+          - runs-on: windows-latest
+            python-version: '3.10'
+            default-channel: 'conda-forge'
+            test-type: conda-rattler-solver
+            test-group: 1
+          - runs-on: windows-latest
+            python-version: '3.10'
+            default-channel: 'conda-forge'
+            test-type: integration
+            test-group: 1
+          - runs-on: windows-latest
+            python-version: '3.10'
+            default-channel: 'conda-forge'
+            test-type: integration
+            test-group: 2
+          - runs-on: windows-latest
+            python-version: '3.10'
+            default-channel: 'conda-forge'
+            test-type: integration
+            test-group: 3
+          - runs-on: windows-latest
+            python-version: '3.13'
+            default-channel: 'conda-forge'
+            test-type: unit
+            test-group: 1
+          - runs-on: windows-latest
+            python-version: '3.13'
+            default-channel: 'conda-forge'
+            test-type: unit
+            test-group: 2
+    env:
+      ErrorActionPreference: Stop  # powershell exit immediately on error
+      PYTEST_MARKER: ${{ matrix.test-type == 'unit' && 'not integration and not benchmark' || 'integration and not benchmark' }}
+      PYTEST_SPLITS: ${{ matrix.test-type == 'unit' && '2' || '3' }}
+
+    steps:
+      - name: Checkout conda/conda # CONDA-RATTLER-SOLVER CHANGE
+        uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
+        with:
+          fetch-depth: 0
+          repository: conda/conda
+          path: conda  # CONDA-RATTLER-SOLVER CHANGE
+          ref: ${{ env.CONDA_REF }}
+
+      # CONDA-RATTLER-SOLVER CHANGE
+      - name: Checkout conda-rattler-solver
+        uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
+        with:
+          fetch-depth: 0
+          path: conda-rattler-solver
+      # /CONDA-RATTLER-SOLVER CHANGE
+
+      - name: Hash + Timestamp
+        shell: bash  # use bash to run date command
+        run: echo "HASH=${{ runner.os }}-${{ runner.arch }}-Py${{ matrix.python-version }}-${{ matrix.default-channel }}-${{ matrix.test-type }}-${{ matrix.test-group }}-$(date -u "+%Y%m")" >> $GITHUB_ENV
+
+      - name: Cache Conda
+        uses: actions/cache@8b402f58fbc84540c8b491a91e594a4576fec3d7 # v5.0.2
+        with:
+          # Use faster GNU tar for all runners
+          enableCrossOsArchive: true
+          path: D:\conda_pkgs_dir
+          key: cache-${{ env.HASH }}
+
+      - name: Setup Miniconda
+        uses: conda-incubator/setup-miniconda@8ee1f361103df19b6f8c8655fd3967a8ecb162d5 # v4.0.1
+        with:
+          # CONDA-RATTLER-SOLVER CHANGE: add conda\
+          condarc-file: conda\.github\condarc-${{ matrix.default-channel }}
+          run-post: false  # skip post cleanup
+          pkgs-dirs: D:\conda_pkgs_dir
+          installation-dir: D:\conda
+
+      - name: Conda Install
+        working-directory: conda  # CONDA-RATTLER-SOLVER CHANGE
+        # CONDA-RATTLER-SOLVER CHANGE: add conda-rattler-solver requirements.txt
+        run: >
+          conda install
+          --yes
+          --quiet
+          --file tests\requirements.txt
+          --file tests\requirements-${{ runner.os }}.txt
+          --file tests\requirements-ci.txt
+          --file tests\requirements-s3.txt
+          python=${{ matrix.python-version }}
+
+      # CONDA-RATTLER-SOLVER CHANGE
+      - name: Install conda-rattler-solver
+        run: python -m pip install -e conda-rattler-solver/
+      #/ CONDA-RATTLER-SOLVER CHANGE
+
+      - name: Conda Info
+        run: python -m conda info --verbose
+
+      - name: Conda Config
+        run: conda config --show-sources
+
+      - name: Conda List
+        run: conda list --show-channel-urls
+
+      - name: Setup PowerShell
+        # for tests/shell, so only necessary for integration tests
+        if: matrix.test-type == 'integration'
+        run: |
+          $PWSH_STABLE = "$env:LOCALAPPDATA\Microsoft\powershell"
+          Invoke-Expression "& { $(Invoke-RestMethod https://aka.ms/install-powershell.ps1) } -Destination `"$PWSH_STABLE`""
+          $PWSH_PREVIEW = "$env:LOCALAPPDATA\Microsoft\powershell-preview"
+          Invoke-Expression "& { $(Invoke-RestMethod https://aka.ms/install-powershell.ps1) } -Preview -Destination `"$PWSH_PREVIEW`""
+          "PWSHPATH=$PWSH_STABLE;$PWSH_PREVIEW" | Out-File -FilePath $env:GITHUB_ENV -Append
+
+      - name: PowerShell Info
+        # for tests/shell, so only necessary for integration tests
+        if: matrix.test-type == 'integration'
+        run: |
+          Get-Command -All powershell
+          "$env:PWSHPATH" -split ";" | ForEach-Object { Get-Command -All "$_\pwsh" }
+
+      - name: Stage upstream xfail plugin
+        if: ${{ matrix.test-type != 'conda-rattler-solver' }}
+        working-directory: conda
+        shell: bash
+        run: cp ../conda-rattler-solver/tests/_pytest_upstream.py tests/_pytest_upstream.py
+
+      - name: Run Upstream Tests
+        # Windows is sensitive to long paths, using `--basetemp=${{ runner.temp }} to
+        # keep the test directories shorter
+        working-directory: conda  # CONDA-RATTLER-SOLVER CHANGE
+        if: ${{ matrix.test-type != 'conda-rattler-solver' }}  # CONDA-RATTLER-SOLVER CHANGE
+        # skip cli startup benchmark test - these benchmarks should only be run by conda
+        # -p: CRS-only xfails (tests/_pytest_upstream.py copied here; not packaged)
+        run: >
+          python -m pytest
+          -p tests._pytest_upstream
+          --cov=conda
+          --basetemp=${{ runner.temp }}
+          --durations-path=durations\${{ runner.os }}.json
+          --group=${{ matrix.test-group }}
+          --splits=${{ env.PYTEST_SPLITS }}
+          --reruns=${{ env.PYTEST_RERUN_FAILURES }}
+          --reruns-delay ${{ env.PYTEST_RERUN_FAILURES_DELAY }}
+          --ignore=tests\cli\test_startup_benchmarks.py
+          -m "${{ env.PYTEST_MARKER }}"
+
+      - name: Upload Coverage
+        uses: codecov/codecov-action@671740ac38dd9b0130fbe1cec585b89eea48d3de # v5.5.2
+        if: false  # CONDA-RATTLER-SOLVER CHANGE
+        with:
+          flags: ${{ runner.os }},${{ runner.arch }},${{ matrix.python-version }},${{ matrix.test-type }}
+          token: ${{ secrets.CODECOV_TOKEN }}  # required
+
+      - name: Upload Test Results
+        if: '!cancelled()'
+        uses: actions/upload-artifact@b7c566a772e6b6bfb58ed0dc250532a479d7789f # v6.0.0
+        with:
+          name: test-results-${{ env.HASH }}
+          include-hidden-files: true
+          # CONDA-RATTLER-SOLVER CHANGE: need to prepend conda\ to the paths
+          path: |
+            conda\.coverage
+            conda\durations\${{ runner.os }}.json
+            conda\test-report.xml
+          retention-days: 1  # temporary, combined in aggregate below
+
+  # linux test suite
+  linux:
+    # only run test suite if there are code changes
+    needs: changes
+    if: github.event_name == 'schedule' || needs.changes.outputs.code == 'true'
+
+    runs-on: ${{ matrix.runs-on }}
+    defaults:
+      run:
+        # https://github.com/conda-incubator/setup-miniconda#use-a-default-shell
+        shell: bash -el {0}  # bash exit immediately on error + login shell
+    strategy:
+      fail-fast: false
+      matrix:
+        include:
+          - runs-on: ubuntu-latest # linux-64
+            python-version: '3.10'
+            default-channel: 'conda-forge'
+            test-type: conda-rattler-solver
+            test-group: 1
+          - runs-on: ubuntu-latest # linux-64
+            python-version: '3.10'
+            default-channel: 'conda-forge'
+            test-type: integration
+            test-group: 1
+          - runs-on: ubuntu-latest # linux-64
+            python-version: '3.10'
+            default-channel: 'conda-forge'
+            test-type: integration
+            test-group: 2
+          - runs-on: ubuntu-latest # linux-64
+            python-version: '3.10'
+            default-channel: 'conda-forge'
+            test-type: integration
+            test-group: 3
+          - runs-on: ubuntu-24.04-arm # linux-aarch64
+            python-version: '3.13'
+            default-channel: 'conda-forge'
+            test-type: unit
+            test-group: 1
+          - runs-on: ubuntu-24.04-arm # linux-aarch64
+            python-version: '3.13'
+            default-channel: 'conda-forge'
+            test-type: unit
+            test-group: 2
+    env:
+      PYTEST_MARKER: ${{ matrix.test-type == 'unit' && 'not integration and not benchmark' || 'integration and not benchmark' }}
+      PYTEST_SPLITS: ${{ matrix.test-type == 'unit' && '2' || '3' }}
+      RUST_BACKTRACE: full
+
+    steps:
+      - name: Checkout conda/conda # CONDA-RATTLER-SOLVER CHANGE
+        uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
+        with:
+          fetch-depth: 0
+          repository: conda/conda
+          path: conda  # CONDA-RATTLER-SOLVER CHANGE
+          ref: ${{ env.CONDA_REF }}
+
+      # CONDA-RATTLER-SOLVER CHANGE
+      - name: Checkout conda-rattler-solver
+        uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
+        with:
+          fetch-depth: 0
+          path: conda-rattler-solver
+      # /CONDA-RATTLER-SOLVER CHANGE
+
+      - name: Hash + Timestamp
+        run: echo "HASH=${{ runner.os }}-${{ runner.arch }}-Py${{ matrix.python-version }}-${{ matrix.default-channel }}-${{ matrix.test-type }}-${{ matrix.test-group }}-$(date -u "+%Y%m")" >> $GITHUB_ENV
+
+      - name: Cache Conda
+        uses: actions/cache@8b402f58fbc84540c8b491a91e594a4576fec3d7 # v5.0.2
+        with:
+          path: ~/conda_pkgs_dir
+          key: cache-${{ env.HASH }}
+
+      - name: Setup Miniconda
+        uses: conda-incubator/setup-miniconda@8ee1f361103df19b6f8c8655fd3967a8ecb162d5 # v4.0.1
+        with:
+          # CONDA-RATTLER-SOLVER CHANGE: add conda/
+          condarc-file: conda/.github/condarc-${{ matrix.default-channel }}
+          run-post: false  # skip post cleanup
+
+      - name: Conda Install
+        working-directory: conda
+        run: conda install
+          --yes
+          --quiet
+          --file tests/requirements.txt
+          --file tests/requirements-${{ runner.os }}.txt
+          --file tests/requirements-ci.txt
+          --file tests/requirements-s3.txt
+          python=${{ matrix.python-version }}
+
+      # CONDA-RATTLER-SOLVER CHANGE
+      - name: Install conda-rattler-solver
+        run: python -m pip install -e conda-rattler-solver/
+      #/ CONDA-RATTLER-SOLVER CHANGE
+
+      - name: Conda Info
+        run: python -m conda info --verbose
+
+      - name: Conda Config
+        run: conda config --show-sources
+
+      - name: Conda List
+        run: conda list --show-channel-urls
+
+      - name: Setup Shells
+        if: matrix.test-type == 'integration'
+        run: sudo apt update && sudo apt install ash csh fish tcsh xonsh zsh
+      
+      - name: Stage upstream xfail plugin
+        if: ${{ matrix.test-type != 'conda-rattler-solver' }}
+        working-directory: conda
+        shell: bash
+        run: cp ../conda-rattler-solver/tests/_pytest_upstream.py tests/_pytest_upstream.py
+
+      - name: Run Tests
+        working-directory: conda  # CONDA-RATTLER-SOLVER CHANGE
+        if: ${{ matrix.test-type != 'conda-rattler-solver' }}  # CONDA-RATTLER-SOLVER CHANGE
+        # skip cli startup benchmark test - these benchmarks should only be run by conda
+        # -p: CRS-only xfails (tests/_pytest_upstream.py copied here; not packaged)
+        run: python -m pytest
+          -p tests._pytest_upstream
+          --cov=conda
+          --durations-path=durations/${{ runner.os }}.json
+          --group=${{ matrix.test-group }}
+          --splits=${{ env.PYTEST_SPLITS }}
+          --reruns=${{ env.PYTEST_RERUN_FAILURES }}
+          --reruns-delay ${{ env.PYTEST_RERUN_FAILURES_DELAY }}
+          --ignore=tests/cli/test_startup_benchmarks.py
+          -m "${{ env.PYTEST_MARKER }}"
+
+      - name: Upload Coverage
+        uses: codecov/codecov-action@671740ac38dd9b0130fbe1cec585b89eea48d3de # v5.5.2
+        if: false  # CONDA-RATTLER-SOLVER CHANGE
+        with:
+          flags: ${{ runner.os }},${{ runner.arch }},${{ matrix.python-version }},${{ matrix.test-type }}
+          token: ${{ secrets.CODECOV_TOKEN }}  # required
+
+      - name: Upload Test Results
+        if: '!cancelled()'
+        uses: actions/upload-artifact@b7c566a772e6b6bfb58ed0dc250532a479d7789f # v6.0.0
+        with:
+          name: test-results-${{ env.HASH }}
+          path: |
+            conda/.coverage
+            conda/durations/${{ runner.os }}.json
+            conda/test-report.xml
+          retention-days: 1  # temporary, combined in aggregate below
+
+  # macos test suite
+  macos:
+    # only run test suite if there are code changes
+    needs: changes
+    if: github.event_name == 'schedule' || needs.changes.outputs.code == 'true'
+
+    runs-on: ${{ matrix.runs-on }}
+    defaults:
+      run:
+        # https://github.com/conda-incubator/setup-miniconda#use-a-default-shell
+        shell: bash -el {0}  # bash exit immediately on error + login shell
+    strategy:
+      fail-fast: false
+      matrix:
+        include:
+          - runs-on: macos-latest # osx-arm64
+            python-version: '3.10'
+            default-channel: 'conda-forge'
+            test-type: conda-rattler-solver
+            test-group: 1
+          - runs-on: macos-latest # osx-arm64
+            python-version: '3.10'
+            default-channel: 'conda-forge'
+            test-type: integration
+            test-group: 1
+          - runs-on: macos-latest # osx-arm64
+            python-version: '3.10'
+            default-channel: 'conda-forge'
+            test-type: integration
+            test-group: 2
+          - runs-on: macos-latest # osx-arm64
+            python-version: '3.10'
+            default-channel: 'conda-forge'
+            test-type: integration
+            test-group: 3
+          - runs-on: macos-latest # osx-arm64
+            python-version: '3.14'
+            default-channel: 'conda-forge'
+            test-type: unit
+            test-group: 1
+          - runs-on: macos-latest # osx-arm64
+            python-version: '3.14'
+            default-channel: 'conda-forge'
+            test-type: unit
+            test-group: 2
+    env:
+      PYTEST_MARKER: ${{ matrix.test-type == 'unit' && 'not integration and not benchmark' || 'integration and not benchmark' }}
+      PYTEST_SPLITS: ${{ matrix.test-type == 'unit' && '2' || '3' }}
+
+    steps:
+      - name: Checkout conda/conda # CONDA-RATTLER-SOLVER CHANGE
+        uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
+        with:
+          fetch-depth: 0
+          repository: conda/conda
+          path: conda  # CONDA-RATTLER-SOLVER CHANGE
+          ref: ${{ env.CONDA_REF }}
+
+      # CONDA-RATTLER-SOLVER CHANGE
+      - name: Checkout conda-rattler-solver
+        uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
+        with:
+          fetch-depth: 0
+          path: conda-rattler-solver
+      # /CONDA-RATTLER-SOLVER CHANGE
+
+      - name: Hash + Timestamp
+        run: echo "HASH=${{ runner.os }}-${{ runner.arch }}-Py${{ matrix.python-version }}-${{ matrix.default-channel }}-${{ matrix.test-type }}-${{ matrix.test-group }}-$(date -u "+%Y%m")" >> $GITHUB_ENV
+
+      - name: Cache Conda
+        uses: actions/cache@8b402f58fbc84540c8b491a91e594a4576fec3d7 # v5.0.2
+        with:
+          path: ~/conda_pkgs_dir
+          key: cache-${{ env.HASH }}
+
+      - name: Setup Miniconda
+        uses: conda-incubator/setup-miniconda@8ee1f361103df19b6f8c8655fd3967a8ecb162d5 # v4.0.1
+        with:
+          condarc-file: conda/.github/condarc-${{ matrix.default-channel }}  # CONDA-RATTLER-SOLVER CHANGE: add conda/
+          run-post: false  # skip post cleanup
+          miniconda-version: ${{ matrix.default-channel == 'defaults' && 'latest' || null }}
+          miniforge-version: ${{ matrix.default-channel == 'conda-forge' && 'latest' || null }}
+
+      - name: Conda Install
+        working-directory: conda # CONDA-RATTLER-SOLVER CHANGE
+        # CONDA-RATTLER-SOLVER CHANGE: add conda-rattler-solver requirements.txt
+        run: >
+          conda install
+          --yes
+          --quiet
+          --file tests/requirements.txt
+          --file tests/requirements-ci.txt
+          --file tests/requirements-s3.txt
+          python=${{ matrix.python-version }}
+
+      # CONDA-RATTLER-SOLVER CHANGE
+      - name: Install conda-rattler-solver
+        run: python -m pip install -e conda-rattler-solver/
+      #/ CONDA-RATTLER-SOLVER CHANGE
+
+      - name: Conda Info
+        run: python -m conda info --verbose
+
+      - name: Conda Config
+        run: conda config --show-sources
+
+      - name: Conda List
+        run: conda list --show-channel-urls
+
+      - name: Setup Shells
+        # for tests/shell, so only necessary for integration tests
+        if: matrix.test-type == 'integration'
+        run: brew update && brew install fish xonsh
+
+      - name: Stage upstream xfail plugin
+        if: ${{ matrix.test-type != 'conda-rattler-solver' }}
+        working-directory: conda
+        run: cp ../conda-rattler-solver/tests/_pytest_upstream.py tests/_pytest_upstream.py
+
+      - name: Run Tests
+        working-directory: conda  # CONDA-RATTLER-SOLVER CHANGE
+        if: ${{ matrix.test-type != 'conda-rattler-solver' }}  # CONDA-RATTLER-SOLVER CHANGE
+        # skip cli startup benchmark test - these benchmarks should only be run by conda
+        # -p: CRS-only xfails (tests/_pytest_upstream.py copied here; not packaged)
+        run: >
+          python -m pytest
+          -p tests._pytest_upstream
+          --cov=conda
+          --durations-path=durations/${{ runner.os }}.json
+          --group=${{ matrix.test-group }}
+          --splits=${{ env.PYTEST_SPLITS }}
+          --reruns=${{ env.PYTEST_RERUN_FAILURES }}
+          --reruns-delay ${{ env.PYTEST_RERUN_FAILURES_DELAY }}
+          --ignore=tests/cli/test_startup_benchmarks.py
+          -m "${{ env.PYTEST_MARKER }}"
+
+      - name: Upload Coverage
+        uses: codecov/codecov-action@671740ac38dd9b0130fbe1cec585b89eea48d3de # v5.5.2
+        if: false  # CONDA-RATTLER-SOLVER CHANGE
+        with:
+          flags: ${{ runner.os }},${{ runner.arch }},${{ matrix.python-version }},${{ matrix.test-type }}
+          token: ${{ secrets.CODECOV_TOKEN }}  # required
+
+      - name: Upload Test Results
+        if: '!cancelled()'
+        uses: actions/upload-artifact@b7c566a772e6b6bfb58ed0dc250532a479d7789f # v6.0.0
+        with:
+          name: test-results-${{ env.HASH }}
+          include-hidden-files: true
+          # CONDA-RATTLER-SOLVER CHANGE: need to prepend conda/ to the paths
+          path: |
+            conda/.coverage
+            conda/durations/${{ runner.os }}.json
+            conda/test-report.xml
+          retention-days: 1  # temporary, combined in aggregate below
+
+  # aggregate and upload
+  aggregate:
+    # only aggregate test suite if there are code changes
+    needs: [changes, windows, linux, macos]
+    if: >-
+      !cancelled()
+      && (
+        github.event_name == 'schedule'
+        || needs.changes.outputs.code == 'true'
+      )
+
+    runs-on: ubuntu-latest
+    steps:
+      - name: Download Artifacts
+        uses: actions/download-artifact@37930b1c2abaa49bbe596cd826c3c89aef350131 # v7.0.0
+
+      - name: Upload Combined Test Results
+        # provides one downloadable archive of all matrix run test results for further analysis
+        uses: actions/upload-artifact@b7c566a772e6b6bfb58ed0dc250532a479d7789f # v6.0.0
+        with:
+          name: test-results-${{ github.sha }}-all
+          include-hidden-files: true
+          path: test-results-*
+          retention-days: 7  # for durations.yml workflow
+
+      - name: Test Summary
+        uses: test-summary/action@31493c76ec9e7aa675f1585d3ed6f1da69269a86 # v2.4
+        with:
+          paths: test-results-*/test-report.xml
+
+  # required check
+  analyze:
+    needs: [windows, linux, macos, aggregate]
+    if: '!cancelled()'
+
+    runs-on: ubuntu-latest
+    steps:
+      - name: Determine Success
+        uses: re-actors/alls-green@05ac9388f0aebcb5727afa17fcccfecd6f8ec5fe # v1.2.2
+        id: alls-green
+        with:
+          # permit jobs to be skipped if there are no code changes (see changes job)
+          allowed-skips: ${{ toJSON(needs) }}
+          jobs: ${{ toJSON(needs) }}
+
+      - name: Checkout our source
+        if: always() && github.event_name == 'schedule' && steps.alls-green.outputs.result == 'failure'
+        uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
+
+      - name: Report failures
+        if: always() && github.event_name == 'schedule' && steps.alls-green.outputs.result == 'failure'
+        uses: JasonEtco/create-an-issue@1b14a70e4d8dc185e5cc76d3bec9eab20257b2c5 # v2.9.2
+        env:
+          GITHUB_TOKEN: ${{ secrets.AUTO_REPORT_TEST_FAILURE }}
+          RUN_ID: ${{ github.run_id }}
+          TITLE: Tests failed
+        with:
+          filename: .github/TEST_FAILURE_REPORT_TEMPLATE.md
+          update_existing: false
+
+  # canary builds
+  build:
+    needs: [analyze]
+    # only build canary build if
+    # - prior steps succeeded,
+    # - this is the main repo, and
+    # - we are on the main, feature, or release branch
+    if: >-
+      !cancelled()
+      && !github.event.repository.fork
+      && (
+        github.ref_name == 'main'
+        || startsWith(github.ref_name, 'feature/')
+        || endsWith(github.ref_name, '.x')
+      )
+    runs-on: ubuntu-latest
+    steps:
+      # Clean checkout of specific git ref needed for package metadata version
+      # which needs env vars GIT_DESCRIBE_TAG and GIT_BUILD_STR:
+      - name: Checkout Source
+        uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
+        with:
+          ref: ${{ github.ref }}
+          clean: true
+          fetch-depth: 0
+
+      # Explicitly use Python 3.11 since each of the OSes has a different default Python
+      - name: Setup Python
+        uses: actions/setup-python@83679a892e2d95755f2dac6acb0bfd1e9ac5d548 # v6.1.0
+        with:
+          python-version: '3.11'
+
+      - name: Detect Label
+        shell: python
+        run: |
+          import re
+          from pathlib import Path
+          from os import environ
+          from subprocess import check_output
+
+          # unless otherwise specified, commits are uploaded to the dev label
+          # e.g., `main` branch commits
+          envs = {"ANACONDA_ORG_LABEL": "dev"}
+
+          if "${{ github.ref_name }}".startswith("feature/"):
+              # feature branch commits are uploaded to a custom label
+              envs["ANACONDA_ORG_LABEL"] = "${{ github.ref_name }}"
+          elif re.match(r"\d+(\.\d+)+\.x", "${{ github.ref_name }}"):
+              # release branch commits are added to the rc label
+              # see https://github.com/conda/infrastructure/issues/760
+              _, name = "${{ github.repository }}".split("/")
+              envs["ANACONDA_ORG_LABEL"] = f"rc-{name}-${{ github.ref_name }}"
+
+              # if no releases have occurred on this branch yet then `git describe --tag`
+              # will misleadingly produce a version number relative to the last release
+              # and not relative to the current release branch, if this is the case we need
+              # to override the version with a derivative of the branch name
+
+              # override the version if `git describe --tag` does not start with the branch version
+              last_release = check_output(["git", "describe", "--tag"], text=True).strip()
+              prefix = "${{ github.ref_name }}"[:-1]  # without x suffix
+              if not last_release.startswith(prefix):
+                  envs["VERSION_OVERRIDE"] = f"{prefix}0"
+
+          Path(environ["GITHUB_ENV"]).write_text("\n".join(f"{name}={value}" for name, value in envs.items()))
+
+      - name: Create & Upload
+        uses: conda/actions/canary-release@7f6830b1428a9bd47f0b068892c77eae95207037 # v26.1.0
+        env:
+          # Run conda-build in isolated activation to properly package conda
+          _CONDA_BUILD_ISOLATED_ACTIVATION: 1
+        with:
+          package-name: ${{ github.event.repository.name }}
+          subdir: noarch
+          anaconda-org-channel: conda-canary
+          anaconda-org-label: ${{ env.ANACONDA_ORG_LABEL }}
+          anaconda-org-token: ${{ secrets.ANACONDA_ORG_CONDA_CANARY_TOKEN }}
+          conda-build-arguments: '--override-channels -c conda-forge'

--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -72,53 +72,32 @@ jobs:
               - 'recipe/*'
           # /CONDA-RATTLER-SOLVER CHANGE
 
-  # windows test suite
-  windows:
+  test:
     # only run test suite if there are code changes
     needs: changes
     if: github.event_name == 'schedule' || needs.changes.outputs.code == 'true'
 
-    runs-on: ${{ matrix.runs-on }}
+    runs-on: ${{ matrix.os }}
     strategy:
       fail-fast: false
       matrix:
+        os: [ubuntu-latest, windows-latest]
+        pixi-env: ["test-py310", "test-py311", "test-py312", "test-py313", "test-py314"]
         include:
-          - runs-on: windows-latest
-            python-version: '3.10'
-            default-channel: 'conda-forge'
-            test-type: conda-rattler-solver
-            test-group: 1
-          - runs-on: windows-latest
-            python-version: '3.10'
-            default-channel: 'conda-forge'
-            test-type: integration
-            test-group: 1
-          - runs-on: windows-latest
-            python-version: '3.10'
-            default-channel: 'conda-forge'
-            test-type: integration
-            test-group: 2
-          - runs-on: windows-latest
-            python-version: '3.10'
-            default-channel: 'conda-forge'
-            test-type: integration
-            test-group: 3
-          - runs-on: windows-latest
-            python-version: '3.13'
-            default-channel: 'conda-forge'
-            test-type: unit
-            test-group: 1
-          - runs-on: windows-latest
-            python-version: '3.13'
-            default-channel: 'conda-forge'
-            test-type: unit
-            test-group: 2
+          - os: macos-latest
+            pixi-env: "test-py314"
     env:
-      ErrorActionPreference: Stop  # powershell exit immediately on error
-      PYTEST_MARKER: ${{ matrix.test-type == 'unit' && 'not integration and not benchmark' || 'integration and not benchmark' }}
-      PYTEST_SPLITS: ${{ matrix.test-type == 'unit' && '2' || '3' }}
-
+      PIXI_ENV_NAME: ${{ matrix.pixi-env }}
+      PYTEST_RERUN_FAILURES: 2
+      PYTEST_RERUN_FAILURES_DELAY: 3
+      CONDA_REF: main
     steps:
+      - name: Checkout conda-rattler-solver
+        uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
+        with:
+          fetch-depth: 0
+          path: conda-rattler-solver
+
       - name: Checkout conda/conda # CONDA-RATTLER-SOLVER CHANGE
         uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
         with:
@@ -127,118 +106,33 @@ jobs:
           path: conda  # CONDA-RATTLER-SOLVER CHANGE
           ref: ${{ env.CONDA_REF }}
 
-      # CONDA-RATTLER-SOLVER CHANGE
-      - name: Checkout conda-rattler-solver
-        uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
-        with:
-          fetch-depth: 0
-          path: conda-rattler-solver
-      # /CONDA-RATTLER-SOLVER CHANGE
-
       - name: Hash + Timestamp
         shell: bash  # use bash to run date command
         run: echo "HASH=${{ runner.os }}-${{ runner.arch }}-Py${{ matrix.python-version }}-${{ matrix.default-channel }}-${{ matrix.test-type }}-${{ matrix.test-group }}-$(date -u "+%Y%m")" >> $GITHUB_ENV
 
-      - name: Cache Conda
-        uses: actions/cache@55cc8345863c7cc4c66a329aec7e433d2d1c52a9 # v6.1.0
+      - name: Setup env
+        uses: prefix-dev/setup-pixi@5185adfbffb4bd703da3010310260805d89ebb11 # v0.9.6
         with:
-          # Use faster GNU tar for all runners
-          enableCrossOsArchive: true
-          path: D:\conda_pkgs_dir
-          key: cache-${{ env.HASH }}
+          working-directory: conda-rattler-solver
+          environments: ${{ env.PIXI_ENV_NAME }}
 
-      - name: Setup Miniconda
-        uses: conda-incubator/setup-miniconda@8ee1f361103df19b6f8c8655fd3967a8ecb162d5 # v4.0.1
-        with:
-          # CONDA-RATTLER-SOLVER CHANGE: add conda\
-          condarc-file: conda\.github\condarc-${{ matrix.default-channel }}
-          run-post: false  # skip post cleanup
-          pkgs-dirs: D:\conda_pkgs_dir
-          installation-dir: D:\conda
+      - name: Fix Ubuntu configuration
+        if: startswith(matrix.os, 'ubuntu-')
+        run:
+          # Remove global pip config that interferes with isolated testing
+          # See: https://github.com/actions/runner-images/blob/6d025759810a/images/ubuntu/scripts/build/install-python.sh#L15-L21
+          sudo rm /etc/pip.conf
 
-      - name: Conda Install
-        working-directory: conda  # CONDA-RATTLER-SOLVER CHANGE
-        # CONDA-RATTLER-SOLVER CHANGE: add conda-rattler-solver requirements.txt
-        run: >
-          conda install
-          --yes
-          --quiet
-          --file tests\requirements.txt
-          --file tests\requirements-${{ runner.os }}.txt
-          --file tests\requirements-ci.txt
-          --file tests\requirements-s3.txt
-          --file ..\conda-rattler-solver\dev\requirements.txt
-          --file ..\conda-rattler-solver\tests\requirements.txt
-          python=${{ matrix.python-version }}
-
-      # CONDA-RATTLER-SOLVER CHANGE
-      - name: Install conda-rattler-solver
-        run: python -m pip install -e conda-rattler-solver/ --no-deps
-      #/ CONDA-RATTLER-SOLVER CHANGE
-
-      - name: Conda Info
-        run: python -m conda info --verbose
-
-      - name: Conda Config
-        run: conda config --show-sources
-
-      - name: Conda List
-        run: conda list --show-channel-urls
-
-      - name: Setup PowerShell
-        # for tests/shell, so only necessary for integration tests
-        if: matrix.test-type == 'integration'
-        run: |
-          $PWSH_STABLE = "$env:LOCALAPPDATA\Microsoft\powershell"
-          Invoke-Expression "& { $(Invoke-RestMethod https://aka.ms/install-powershell.ps1) } -Destination `"$PWSH_STABLE`""
-          $PWSH_PREVIEW = "$env:LOCALAPPDATA\Microsoft\powershell-preview"
-          Invoke-Expression "& { $(Invoke-RestMethod https://aka.ms/install-powershell.ps1) } -Preview -Destination `"$PWSH_PREVIEW`""
-          "PWSHPATH=$PWSH_STABLE;$PWSH_PREVIEW" | Out-File -FilePath $env:GITHUB_ENV -Append
-
-      - name: PowerShell Info
-        # for tests/shell, so only necessary for integration tests
-        if: matrix.test-type == 'integration'
-        run: |
-          Get-Command -All powershell
-          "$env:PWSHPATH" -split ";" | ForEach-Object { Get-Command -All "$_\pwsh" }
-
-      - name: Stage upstream xfail plugin
-        if: ${{ matrix.test-type != 'conda-rattler-solver' }}
-        working-directory: conda
-        shell: bash
-        run: cp ../conda-rattler-solver/tests/_pytest_upstream.py tests/_pytest_upstream.py
-
-      - name: Run Upstream Tests
-        # Windows is sensitive to long paths, using `--basetemp=${{ runner.temp }} to
-        # keep the test directories shorter
-        working-directory: conda  # CONDA-RATTLER-SOLVER CHANGE
-        if: ${{ matrix.test-type != 'conda-rattler-solver' }}  # CONDA-RATTLER-SOLVER CHANGE
-        # skip cli startup benchmark test - these benchmarks should only be run by conda
-        # -p: CRS-only xfails (tests/_pytest_upstream.py copied here; not packaged)
-        run: >
-          python -m pytest
-          -p tests._pytest_upstream
-          --cov=conda
-          --basetemp=${{ runner.temp }}
-          --durations-path=durations\${{ runner.os }}.json
-          --group=${{ matrix.test-group }}
-          --splits=${{ env.PYTEST_SPLITS }}
-          --reruns=${{ env.PYTEST_RERUN_FAILURES }}
-          --reruns-delay ${{ env.PYTEST_RERUN_FAILURES_DELAY }}
-          --ignore=tests\cli\test_startup_benchmarks.py
-          -m "${{ env.PYTEST_MARKER }}"
-
-      # CONDA-RATTLER-SOLVER CHANGE
-      - name: Run conda-rattler-solver Tests
+      - name: Run tests
         working-directory: conda-rattler-solver
-        if: ${{ matrix.test-type == 'conda-rattler-solver' }}
-        shell: bash -el {0}
+        env:
+          CHANNELS: ${{ env.PIXI_ENV_NAME == 'test-canary' && 'conda-forge, conda-canary/label/dev' || 'conda-forge' }}
         run: |
-          python -m pip install -e ../conda/ --no-deps
-          python -m conda init --all
-          . $CONDA_PREFIX/etc/profile.d/conda.sh
-          python -m pytest -vv -m "not slow" --reruns=${{ env.PYTEST_RERUN_FAILURES }} --reruns-delay=${{ env.PYTEST_RERUN_FAILURES_DELAY }} --durations=16
-      #/ CONDA-RATTLER-SOLVER CHANGE
+          pixi reinstall --environment ${{ env.PIXI_ENV_NAME }} conda-pypi
+          echo "channels: [${{ env.CHANNELS }}]" > .pixi/envs/${{ env.PIXI_ENV_NAME }}/.condarc
+          pixi run --environment ${{ env.PIXI_ENV_NAME }} conda info
+          pixi run --environment ${{ env.PIXI_ENV_NAME }} test -vv -m "not slow" --reruns=${{ env.PYTEST_RERUN_FAILURES }} --reruns-delay=${{ env.PYTEST_RERUN_FAILURES_DELAY }} --durations=16
+
 
       - name: Upload Coverage
         uses: codecov/codecov-action@fb8b3582c8e4def4969c97caa2f19720cb33a72f # v7.0.0
@@ -260,343 +154,10 @@ jobs:
             conda\test-report.xml
           retention-days: 1  # temporary, combined in aggregate below
 
-  # linux test suite
-  linux:
-    # only run test suite if there are code changes
-    needs: changes
-    if: github.event_name == 'schedule' || needs.changes.outputs.code == 'true'
-
-    runs-on: ${{ matrix.runs-on }}
-    defaults:
-      run:
-        # https://github.com/conda-incubator/setup-miniconda#use-a-default-shell
-        shell: bash -el {0}  # bash exit immediately on error + login shell
-    strategy:
-      fail-fast: false
-      matrix:
-        include:
-          - runs-on: ubuntu-latest # linux-64
-            python-version: '3.10'
-            default-channel: 'conda-forge'
-            test-type: conda-rattler-solver
-            test-group: 1
-          - runs-on: ubuntu-latest # linux-64
-            python-version: '3.10'
-            default-channel: 'conda-forge'
-            test-type: integration
-            test-group: 1
-          - runs-on: ubuntu-latest # linux-64
-            python-version: '3.10'
-            default-channel: 'conda-forge'
-            test-type: integration
-            test-group: 2
-          - runs-on: ubuntu-latest # linux-64
-            python-version: '3.10'
-            default-channel: 'conda-forge'
-            test-type: integration
-            test-group: 3
-          - runs-on: ubuntu-24.04-arm # linux-aarch64
-            python-version: '3.13'
-            default-channel: 'conda-forge'
-            test-type: unit
-            test-group: 1
-          - runs-on: ubuntu-24.04-arm # linux-aarch64
-            python-version: '3.13'
-            default-channel: 'conda-forge'
-            test-type: unit
-            test-group: 2
-    env:
-      PYTEST_MARKER: ${{ matrix.test-type == 'unit' && 'not integration and not benchmark' || 'integration and not benchmark' }}
-      PYTEST_SPLITS: ${{ matrix.test-type == 'unit' && '2' || '3' }}
-      RUST_BACKTRACE: full
-
-    steps:
-      - name: Checkout conda/conda # CONDA-RATTLER-SOLVER CHANGE
-        uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
-        with:
-          fetch-depth: 0
-          repository: conda/conda
-          path: conda  # CONDA-RATTLER-SOLVER CHANGE
-          ref: ${{ env.CONDA_REF }}
-
-      # CONDA-RATTLER-SOLVER CHANGE
-      - name: Checkout conda-rattler-solver
-        uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
-        with:
-          fetch-depth: 0
-          path: conda-rattler-solver
-      # /CONDA-RATTLER-SOLVER CHANGE
-
-      - name: Hash + Timestamp
-        run: echo "HASH=${{ runner.os }}-${{ runner.arch }}-Py${{ matrix.python-version }}-${{ matrix.default-channel }}-${{ matrix.test-type }}-${{ matrix.test-group }}-$(date -u "+%Y%m")" >> $GITHUB_ENV
-
-      - name: Cache Conda
-        uses: actions/cache@55cc8345863c7cc4c66a329aec7e433d2d1c52a9 # v6.1.0
-        with:
-          path: ~/conda_pkgs_dir
-          key: cache-${{ env.HASH }}
-
-      - name: Setup Miniconda
-        uses: conda-incubator/setup-miniconda@8ee1f361103df19b6f8c8655fd3967a8ecb162d5 # v4.0.1
-        with:
-          # CONDA-RATTLER-SOLVER CHANGE: add conda/
-          condarc-file: conda/.github/condarc-${{ matrix.default-channel }}
-          run-post: false  # skip post cleanup
-
-      - name: Conda Install
-        working-directory: conda
-        run: conda install
-          --yes
-          --quiet
-          --file tests/requirements.txt
-          --file tests/requirements-${{ runner.os }}.txt
-          --file tests/requirements-ci.txt
-          --file tests/requirements-s3.txt
-          --file ../conda-rattler-solver/dev/requirements.txt
-          --file ../conda-rattler-solver/tests/requirements.txt
-          python=${{ matrix.python-version }}
-
-      # CONDA-RATTLER-SOLVER CHANGE
-      - name: Install conda-rattler-solver
-        run: python -m pip install -e conda-rattler-solver/ --no-deps
-      #/ CONDA-RATTLER-SOLVER CHANGE
-
-      - name: Conda Info
-        run: python -m conda info --verbose
-
-      - name: Conda Config
-        run: conda config --show-sources
-
-      - name: Conda List
-        run: conda list --show-channel-urls
-
-      - name: Setup Shells
-        if: matrix.test-type == 'integration'
-        run: sudo apt update && sudo apt install ash csh fish tcsh xonsh zsh
-
-      - name: Stage upstream xfail plugin
-        if: ${{ matrix.test-type != 'conda-rattler-solver' }}
-        working-directory: conda
-        run: cp ../conda-rattler-solver/tests/_pytest_upstream.py tests/_pytest_upstream.py
-
-      - name: Run Tests
-        working-directory: conda  # CONDA-RATTLER-SOLVER CHANGE
-        if: ${{ matrix.test-type != 'conda-rattler-solver' }}  # CONDA-RATTLER-SOLVER CHANGE
-        # skip cli startup benchmark test - these benchmarks should only be run by conda
-        # -p: CRS-only xfails (tests/_pytest_upstream.py copied here; not packaged)
-        run: python -m pytest
-          -p tests._pytest_upstream
-          --cov=conda
-          --durations-path=durations/${{ runner.os }}.json
-          --group=${{ matrix.test-group }}
-          --splits=${{ env.PYTEST_SPLITS }}
-          --reruns=${{ env.PYTEST_RERUN_FAILURES }}
-          --reruns-delay ${{ env.PYTEST_RERUN_FAILURES_DELAY }}
-          --ignore=tests/cli/test_startup_benchmarks.py
-          -m "${{ env.PYTEST_MARKER }}"
-
-      # CONDA-RATTLER-SOLVER CHANGE
-      - name: Run conda-rattler-solver Tests
-        working-directory: conda-rattler-solver
-        if: ${{ matrix.test-type == 'conda-rattler-solver' }}
-        run: |
-          python -m pip install -e ../conda/ --no-deps
-          python -m conda init --all
-          . $CONDA_PREFIX/etc/profile.d/conda.sh
-          python -m pytest -vv -m "not slow" --reruns=${{ env.PYTEST_RERUN_FAILURES }} --reruns-delay ${{ env.PYTEST_RERUN_FAILURES_DELAY }} --durations=16
-      #/ CONDA-RATTLER-SOLVER CHANGE
-
-      - name: Upload Coverage
-        uses: codecov/codecov-action@fb8b3582c8e4def4969c97caa2f19720cb33a72f # v7.0.0
-        if: false  # CONDA-RATTLER-SOLVER CHANGE
-        with:
-          flags: ${{ runner.os }},${{ runner.arch }},${{ matrix.python-version }},${{ matrix.test-type }}
-          token: ${{ secrets.CODECOV_TOKEN }}  # required
-
-      - name: Upload Test Results
-        if: '!cancelled()'
-        uses: actions/upload-artifact@043fb46d1a93c77aae656e7c1c64a875d1fc6a0a # v7.0.1
-        with:
-          name: test-results-${{ env.HASH }}
-          path: |
-            conda/.coverage
-            conda/durations/${{ runner.os }}.json
-            conda/test-report.xml
-          retention-days: 1  # temporary, combined in aggregate below
-
-  # macos test suite
-  macos:
-    # only run test suite if there are code changes
-    needs: changes
-    if: github.event_name == 'schedule' || needs.changes.outputs.code == 'true'
-
-    runs-on: ${{ matrix.runs-on }}
-    defaults:
-      run:
-        # https://github.com/conda-incubator/setup-miniconda#use-a-default-shell
-        shell: bash -el {0}  # bash exit immediately on error + login shell
-    strategy:
-      fail-fast: false
-      matrix:
-        include:
-          - runs-on: macos-latest # osx-arm64
-            python-version: '3.10'
-            default-channel: 'conda-forge'
-            test-type: conda-rattler-solver
-            test-group: 1
-          - runs-on: macos-latest # osx-arm64
-            python-version: '3.10'
-            default-channel: 'conda-forge'
-            test-type: integration
-            test-group: 1
-          - runs-on: macos-latest # osx-arm64
-            python-version: '3.10'
-            default-channel: 'conda-forge'
-            test-type: integration
-            test-group: 2
-          - runs-on: macos-latest # osx-arm64
-            python-version: '3.10'
-            default-channel: 'conda-forge'
-            test-type: integration
-            test-group: 3
-          - runs-on: macos-latest # osx-arm64
-            python-version: '3.14'
-            default-channel: 'conda-forge'
-            test-type: unit
-            test-group: 1
-          - runs-on: macos-latest # osx-arm64
-            python-version: '3.14'
-            default-channel: 'conda-forge'
-            test-type: unit
-            test-group: 2
-    env:
-      PYTEST_MARKER: ${{ matrix.test-type == 'unit' && 'not integration and not benchmark' || 'integration and not benchmark' }}
-      PYTEST_SPLITS: ${{ matrix.test-type == 'unit' && '2' || '3' }}
-
-    steps:
-      - name: Checkout conda/conda # CONDA-RATTLER-SOLVER CHANGE
-        uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
-        with:
-          fetch-depth: 0
-          repository: conda/conda
-          path: conda  # CONDA-RATTLER-SOLVER CHANGE
-          ref: ${{ env.CONDA_REF }}
-
-      # CONDA-RATTLER-SOLVER CHANGE
-      - name: Checkout conda-rattler-solver
-        uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
-        with:
-          fetch-depth: 0
-          path: conda-rattler-solver
-      # /CONDA-RATTLER-SOLVER CHANGE
-
-      - name: Hash + Timestamp
-        run: echo "HASH=${{ runner.os }}-${{ runner.arch }}-Py${{ matrix.python-version }}-${{ matrix.default-channel }}-${{ matrix.test-type }}-${{ matrix.test-group }}-$(date -u "+%Y%m")" >> $GITHUB_ENV
-
-      - name: Cache Conda
-        uses: actions/cache@55cc8345863c7cc4c66a329aec7e433d2d1c52a9 # v6.1.0
-        with:
-          path: ~/conda_pkgs_dir
-          key: cache-${{ env.HASH }}
-
-      - name: Setup Miniconda
-        uses: conda-incubator/setup-miniconda@8ee1f361103df19b6f8c8655fd3967a8ecb162d5 # v4.0.1
-        with:
-          condarc-file: conda/.github/condarc-${{ matrix.default-channel }}  # CONDA-RATTLER-SOLVER CHANGE: add conda/
-          run-post: false  # skip post cleanup
-          miniconda-version: ${{ matrix.default-channel == 'defaults' && 'latest' || null }}
-          miniforge-version: ${{ matrix.default-channel == 'conda-forge' && 'latest' || null }}
-
-      - name: Conda Install
-        working-directory: conda # CONDA-RATTLER-SOLVER CHANGE
-        # CONDA-RATTLER-SOLVER CHANGE: add conda-rattler-solver requirements.txt
-        run: >
-          conda install
-          --yes
-          --quiet
-          --file tests/requirements.txt
-          --file tests/requirements-ci.txt
-          --file tests/requirements-s3.txt
-          --file ../conda-rattler-solver/dev/requirements.txt
-          --file ../conda-rattler-solver/tests/requirements.txt
-          python=${{ matrix.python-version }}
-
-      # CONDA-RATTLER-SOLVER CHANGE
-      - name: Install conda-rattler-solver
-        run: python -m pip install -e conda-rattler-solver/ --no-deps
-      #/ CONDA-RATTLER-SOLVER CHANGE
-
-      - name: Conda Info
-        run: python -m conda info --verbose
-
-      - name: Conda Config
-        run: conda config --show-sources
-
-      - name: Conda List
-        run: conda list --show-channel-urls
-
-      - name: Setup Shells
-        # for tests/shell, so only necessary for integration tests
-        if: matrix.test-type == 'integration'
-        run: brew update && brew install fish xonsh
-
-      - name: Stage upstream xfail plugin
-        if: ${{ matrix.test-type != 'conda-rattler-solver' }}
-        working-directory: conda
-        run: cp ../conda-rattler-solver/tests/_pytest_upstream.py tests/_pytest_upstream.py
-
-      - name: Run Tests
-        working-directory: conda  # CONDA-RATTLER-SOLVER CHANGE
-        if: ${{ matrix.test-type != 'conda-rattler-solver' }}  # CONDA-RATTLER-SOLVER CHANGE
-        # skip cli startup benchmark test - these benchmarks should only be run by conda
-        # -p: CRS-only xfails (tests/_pytest_upstream.py copied here; not packaged)
-        run: >
-          python -m pytest
-          -p tests._pytest_upstream
-          --cov=conda
-          --durations-path=durations/${{ runner.os }}.json
-          --group=${{ matrix.test-group }}
-          --splits=${{ env.PYTEST_SPLITS }}
-          --reruns=${{ env.PYTEST_RERUN_FAILURES }}
-          --reruns-delay ${{ env.PYTEST_RERUN_FAILURES_DELAY }}
-          --ignore=tests/cli/test_startup_benchmarks.py
-          -m "${{ env.PYTEST_MARKER }}"
-
-      # CONDA-RATTLER-SOLVER CHANGE
-      - name: Run conda-rattler-solver Tests
-        working-directory: conda-rattler-solver
-        if: ${{ matrix.test-type == 'conda-rattler-solver' }}
-        run: |
-          python -m pip install -e ../conda/ --no-deps
-          python -m conda init --all
-          . $CONDA_PREFIX/etc/profile.d/conda.sh
-          python -m pytest -vv -m "not slow" --reruns=${{ env.PYTEST_RERUN_FAILURES }} --reruns-delay ${{ env.PYTEST_RERUN_FAILURES_DELAY }} --durations=16
-      #/ CONDA-RATTLER-SOLVER CHANGE
-
-      - name: Upload Coverage
-        uses: codecov/codecov-action@fb8b3582c8e4def4969c97caa2f19720cb33a72f # v7.0.0
-        if: false  # CONDA-RATTLER-SOLVER CHANGE
-        with:
-          flags: ${{ runner.os }},${{ runner.arch }},${{ matrix.python-version }},${{ matrix.test-type }}
-          token: ${{ secrets.CODECOV_TOKEN }}  # required
-
-      - name: Upload Test Results
-        if: '!cancelled()'
-        uses: actions/upload-artifact@043fb46d1a93c77aae656e7c1c64a875d1fc6a0a # v7.0.1
-        with:
-          name: test-results-${{ env.HASH }}
-          include-hidden-files: true
-          # CONDA-RATTLER-SOLVER CHANGE: need to prepend conda/ to the paths
-          path: |
-            conda/.coverage
-            conda/durations/${{ runner.os }}.json
-            conda/test-report.xml
-          retention-days: 1  # temporary, combined in aggregate below
-
   # aggregate and upload
   aggregate:
     # only aggregate test suite if there are code changes
-    needs: [changes, windows, linux, macos]
+    needs: [changes, test]
     if: >-
       !cancelled()
       && (
@@ -625,7 +186,7 @@ jobs:
 
   # required check
   analyze:
-    needs: [windows, linux, macos, aggregate]
+    needs: [test, aggregate]
     if: '!cancelled()'
 
     runs-on: ubuntu-latest


### PR DESCRIPTION
<!-- Hello! Thanks for submitting a PR! To help make things go a bit more
     smoothly, we would appreciate it if you follow this template. -->

### Description

* Separates upstream (conda) tests from this repos tests
* Uses pixi for running tests

### Checklist - did you ...

<!-- If any of the following items aren't relevant to your contribution,
     please either tick them or use ~strikethrough~ so we know you've gone
     through the checklist. -->

- ~[ ] Add a file to the `news` directory ([using the template](https://github.com/conda/conda-rattler-solver/blob/main/news/TEMPLATE)) for the next release's release notes?~
     <!-- All "significant" changes should get an entry:
            - user-facing changes or enhancements
            - bug fixes
            - deprecations
            - documentation updates
            - etc -->
- ~[ ] Add / update necessary tests?~
- ~[ ] Add / update outdated documentation?~


<!-- Just as a reminder, everyone in all conda org spaces (including PRs)
     must follow the Conda Org Code of Conduct (link below).

     Finally, once again, thanks for your time and effort. If you have any
     feedback in regards to your experience contributing here, please
     let us know!

     Helpful links:
       - Conda Org COC: https://github.com/conda/conda-rattler-solver/blob/main/CODE_OF_CONDUCT.md
       - Contributing docs: https://github.com/conda/conda-rattler-solver/blob/main/CONTRIBUTING.md -->
